### PR TITLE
feat(api): configure IGDB client with Twitch OAuth2 authentication (T…

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -27,6 +27,9 @@ jobs:
           cache: "maven"
 
       - name: Run tests
+        env:
+          IGDB_CLIENT_ID: ${{ secrets.IGDB_CLIENT_ID }}
+          IGDB_CLIENT_SECRET: ${{ secrets.IGDB_CLIENT_SECRET }}
         run: ./mvnw test --batch-mode
 
   build:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@
 - **pnpm**
 - **Docker & Docker Compose**
 - **PostgreSQL** (or use Docker)
+- **Doppler CLI** (for secrets management)
+
+### Doppler Setup
+
+This project uses [Doppler](https://www.doppler.com/) to manage environment variables and secrets.
+
+```bash
+# Install Doppler CLI (macOS)
+brew install dopplerhq/cli/doppler
+
+# Login to Doppler
+doppler login
+
+# Setup project (run in root directory)
+doppler setup
+```
 
 ### API (Spring Boot)
 
@@ -102,11 +118,21 @@ cd api
 # Start PostgreSQL with Docker
 docker compose up -d
 
-# Run the application
-./mvnw spring-boot:run
+# Run the application with Doppler
+doppler run -- ./mvnw spring-boot:run
+
+# Run tests with Doppler (for IGDB integration tests)
+doppler run -- ./mvnw test
 ```
 
 The API will be available at `http://localhost:8080`
+
+#### Required Environment Variables (via Doppler)
+
+| Variable | Description |
+|----------|-------------|
+| `IGDB_CLIENT_ID` | Twitch Client ID for IGDB API |
+| `IGDB_CLIENT_SECRET` | Twitch Client Secret for IGDB API |
 
 ### Web Application (TanStack Start)
 

--- a/api/src/main/java/com/checkpoint/api/config/IgdbClientConfig.java
+++ b/api/src/main/java/com/checkpoint/api/config/IgdbClientConfig.java
@@ -1,0 +1,112 @@
+package com.checkpoint.api.config;
+
+import java.time.Instant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Configuration class for IGDB API client.
+ * Creates a RestClient bean configured with OAuth2 authentication via Twitch.
+ * The access token is automatically managed and refreshed when needed.
+ */
+@Configuration
+public class IgdbClientConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(IgdbClientConfig.class);
+
+    @Value("${igdb.api.client-id}")
+    private String clientId;
+
+    @Value("${igdb.api.client-secret}")
+    private String clientSecret;
+
+    @Value("${igdb.api.base-url}")
+    private String baseUrl;
+
+    @Value("${igdb.api.auth-url}")
+    private String authUrl;
+
+    private String accessToken;
+    private Instant tokenExpiry;
+
+    /**
+     * DTO for Twitch OAuth2 token response.
+     */
+    record TwitchTokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("expires_in") int expiresIn,
+            @JsonProperty("token_type") String tokenType
+    ) {}
+
+    /**
+     * Creates a RestClient bean for IGDB API communication.
+     * The Client-ID and Bearer token are automatically added to every request.
+     *
+     * @return configured RestClient instance
+     */
+    @Bean
+    public RestClient igdbClient() {
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            throw new IllegalArgumentException("IGDB base URL must not be null or empty");
+        }
+        return RestClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("Accept", MediaType.APPLICATION_JSON_VALUE)
+                .requestInterceptor((request, body, execution) -> {
+                    // Ensure we have a valid access token
+                    String token = getOrRefreshAccessToken();
+
+                    // Add required IGDB headers
+                    request.getHeaders().set("Client-ID", clientId);
+                    request.getHeaders().set("Authorization", "Bearer " + token);
+
+                    return execution.execute(request, body);
+                })
+                .build();
+    }
+
+    /**
+     * Gets the current access token, refreshing it if expired or not yet obtained.
+     *
+     * @return valid access token
+     */
+    private synchronized String getOrRefreshAccessToken() {
+        if (accessToken == null || tokenExpiry == null || Instant.now().isAfter(tokenExpiry.minusSeconds(60))) {
+            refreshAccessToken();
+        }
+        return accessToken;
+    }
+
+    /**
+     * Requests a new access token from Twitch OAuth2 endpoint.
+     */
+    private void refreshAccessToken() {
+        log.info("Refreshing IGDB access token...");
+
+        RestClient authClient = RestClient.create();
+
+        String tokenUrl = String.format("%s?client_id=%s&client_secret=%s&grant_type=client_credentials",
+                authUrl, clientId, clientSecret);
+
+        TwitchTokenResponse response = authClient.post()
+                .uri(tokenUrl)
+                .retrieve()
+                .body(TwitchTokenResponse.class);
+
+        if (response != null) {
+            this.accessToken = response.accessToken();
+            this.tokenExpiry = Instant.now().plusSeconds(response.expiresIn());
+            log.info("IGDB access token refreshed successfully. Expires in {} seconds.", response.expiresIn());
+        } else {
+            throw new RuntimeException("Failed to obtain IGDB access token");
+        }
+    }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -7,3 +7,9 @@ spring.datasource.password=secret
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# IGDB API Configuration (via Twitch OAuth2)
+igdb.api.client-id=${IGDB_CLIENT_ID:}
+igdb.api.client-secret=${IGDB_CLIENT_SECRET:}
+igdb.api.base-url=https://api.igdb.com/v4
+igdb.api.auth-url=https://id.twitch.tv/oauth2/token

--- a/api/src/test/java/com/checkpoint/api/integration/IgdbClientIntegrationTest.java
+++ b/api/src/test/java/com/checkpoint/api/integration/IgdbClientIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.checkpoint.api.integration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.RestClient;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for IGDB API client.
+ * These tests require valid IGDB_CLIENT_ID and IGDB_CLIENT_SECRET environment variables to be set.
+ */
+@SpringBootTest
+@Testcontainers
+@EnabledIfEnvironmentVariable(named = "IGDB_CLIENT_ID", matches = ".+")
+class IgdbClientIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    @Qualifier("igdbClient")
+    private RestClient igdbClient;
+
+    /**
+     * Tests that the IGDB client can successfully call the /platforms endpoint
+     * and receive a 200 OK response.
+     * Note: IGDB uses POST requests with body for queries.
+     */
+    @Test
+    void getPlatforms_shouldReturnOk() {
+        var response = igdbClient.post()
+                .uri("/platforms")
+                .body("fields name; limit 10;")
+                .retrieve()
+                .toEntity(String.class);
+
+        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().contains("name"));
+    }
+}


### PR DESCRIPTION
…E-136)

- Add IgdbClientConfig with automatic OAuth2 token management
- Configure client-id and client-secret via Doppler env vars
- Create RestClient bean with auto-injected auth headers
- Add integration test for /platforms endpoint
- Update CI workflow to pass IGDB secrets to tests
- Update README with Doppler setup instructions