### PR TITLE
[TE-138] feat(api): implement Game Import Service with rate limiting (TE-138)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -70,6 +70,11 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-ratelimiter</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/api/src/main/java/com/checkpoint/api/client/IgdbApiClient.java
+++ b/api/src/main/java/com/checkpoint/api/client/IgdbApiClient.java
@@ -1,0 +1,46 @@
+package com.checkpoint.api.client;
+
+import java.util.List;
+
+import com.checkpoint.api.dto.igdb.IgdbGameDto;
+
+/**
+ * Interface for IGDB API client operations.
+ * Abstracts the communication with the IGDB API.
+ */
+public interface IgdbApiClient {
+
+    /**
+     * Fetches recently released games from IGDB.
+     *
+     * @param limit maximum number of games to fetch
+     * @return list of games
+     */
+    List<IgdbGameDto> fetchRecentlyReleasedGames(int limit);
+
+    /**
+     * Fetches games by their IDs from IGDB.
+     *
+     * @param gameIds list of IGDB game IDs
+     * @return list of games
+     */
+    List<IgdbGameDto> fetchGamesByIds(List<Long> gameIds);
+
+    /**
+     * Searches games by name on IGDB.
+     *
+     * @param searchQuery the search term
+     * @param limit maximum number of results
+     * @return list of matching games
+     */
+    List<IgdbGameDto> searchGames(String searchQuery, int limit);
+
+    /**
+     * Fetches top rated games from IGDB.
+     *
+     * @param limit maximum number of games to fetch
+     * @param minRatingCount minimum number of ratings required
+     * @return list of top rated games
+     */
+    List<IgdbGameDto> fetchTopRatedGames(int limit, int minRatingCount);
+}

--- a/api/src/main/java/com/checkpoint/api/client/IgdbApiClientImpl.java
+++ b/api/src/main/java/com/checkpoint/api/client/IgdbApiClientImpl.java
@@ -1,0 +1,161 @@
+package com.checkpoint.api.client;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.checkpoint.api.dto.igdb.IgdbGameDto;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+
+/**
+ * Implementation of {@link IgdbApiClient} with rate limiting.
+ * Uses Resilience4j RateLimiter to ensure we don't exceed IGDB API limits.
+ *
+ * IGDB API allows approximately 4 requests per second, but we use 1 per second
+ * to be safe and avoid any risk of being rate limited.
+ */
+@Component
+public class IgdbApiClientImpl implements IgdbApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(IgdbApiClientImpl.class);
+
+    /**
+     * Common fields to request from IGDB for game data.
+     * Using expanded fields (*) for nested objects.
+     */
+    private static final String GAME_FIELDS = """
+            fields id, name, slug, summary, storyline, first_release_date,
+            rating, rating_count, aggregated_rating, aggregated_rating_count,
+            total_rating, total_rating_count, url,
+            cover.*, genres.*, platforms.*, platforms.platform_logo.*,
+            involved_companies.*, involved_companies.company.*,
+            involved_companies.company.logo.*, screenshots.*,
+            game_modes.*, themes.*, player_perspectives.*;
+            """;
+
+    private final RestClient igdbClient;
+    private final RateLimiter rateLimiter;
+
+    public IgdbApiClientImpl(RestClient igdbClient) {
+        this.igdbClient = igdbClient;
+        this.rateLimiter = createRateLimiter();
+    }
+
+    /**
+     * Creates a rate limiter configured for 1 request per second.
+     * This is conservative but ensures we never hit IGDB rate limits.
+     */
+    private RateLimiter createRateLimiter() {
+        RateLimiterConfig config = RateLimiterConfig.custom()
+                .limitRefreshPeriod(Duration.ofSeconds(1))
+                .limitForPeriod(1)
+                .timeoutDuration(Duration.ofSeconds(30))
+                .build();
+
+        RateLimiterRegistry registry = RateLimiterRegistry.of(config);
+        return registry.rateLimiter("igdbApiLimiter");
+    }
+
+    @Override
+    public List<IgdbGameDto> fetchRecentlyReleasedGames(int limit) {
+        log.info("Fetching {} recently released games from IGDB", limit);
+
+        long now = Instant.now().getEpochSecond();
+        long thirtyDaysAgo = now - (30L * 24 * 60 * 60);
+
+        String query = GAME_FIELDS + String.format("""
+                where first_release_date >= %d & first_release_date <= %d;
+                sort first_release_date desc;
+                limit %d;
+                """, thirtyDaysAgo, now, limit);
+
+        return executeQuery("/games", query);
+    }
+
+    @Override
+    public List<IgdbGameDto> fetchGamesByIds(List<Long> gameIds) {
+        if (gameIds == null || gameIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        log.info("Fetching {} games by IDs from IGDB", gameIds.size());
+
+        String idsString = String.join(",", gameIds.stream().map(String::valueOf).toList());
+        String query = GAME_FIELDS + String.format("""
+                where id = (%s);
+                limit %d;
+                """, idsString, gameIds.size());
+
+        return executeQuery("/games", query);
+    }
+
+    @Override
+    public List<IgdbGameDto> searchGames(String searchQuery, int limit) {
+        if (searchQuery == null || searchQuery.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        log.info("Searching for games matching '{}' on IGDB", searchQuery);
+
+        String query = GAME_FIELDS + String.format("""
+                search "%s";
+                limit %d;
+                """, searchQuery.replace("\"", "\\\""), limit);
+
+        return executeQuery("/games", query);
+    }
+
+    @Override
+    public List<IgdbGameDto> fetchTopRatedGames(int limit, int minRatingCount) {
+        log.info("Fetching top {} rated games from IGDB (min {} ratings)", limit, minRatingCount);
+
+        String query = GAME_FIELDS + String.format("""
+                where total_rating_count >= %d & total_rating != null;
+                sort total_rating desc;
+                limit %d;
+                """, minRatingCount, limit);
+
+        return executeQuery("/games", query);
+    }
+
+    /**
+     * Executes a query against the IGDB API with rate limiting.
+     *
+     * @param endpoint the API endpoint (e.g., "/games")
+     * @param query the IGDB API query
+     * @return list of games from the response
+     */
+    private List<IgdbGameDto> executeQuery(String endpoint, String query) {
+        // Wait for rate limiter permission
+        RateLimiter.waitForPermission(rateLimiter);
+
+        log.debug("Executing IGDB query on {}: {}", endpoint, query.replace("\n", " "));
+
+        try {
+            List<IgdbGameDto> result = igdbClient.post()
+                    .uri(endpoint)
+                    .contentType(MediaType.TEXT_PLAIN)
+                    .body(query)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<List<IgdbGameDto>>() {});
+
+            log.debug("IGDB returned {} games", result != null ? result.size() : 0);
+            return result != null ? result : Collections.emptyList();
+
+        } catch (Exception e) {
+            log.error("Error executing IGDB query: {}", e.getMessage(), e);
+            throw new IgdbApiException("Failed to fetch data from IGDB", e);
+        }
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/client/IgdbApiException.java
+++ b/api/src/main/java/com/checkpoint/api/client/IgdbApiException.java
@@ -1,0 +1,15 @@
+package com.checkpoint.api.client;
+
+/**
+ * Exception thrown when an error occurs while communicating with the IGDB API.
+ */
+public class IgdbApiException extends RuntimeException {
+
+    public IgdbApiException(String message) {
+        super(message);
+    }
+
+    public IgdbApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/entities/VideoGame.java
+++ b/api/src/main/java/com/checkpoint/api/entities/VideoGame.java
@@ -30,11 +30,23 @@ public class VideoGame {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    /**
+     * External ID from IGDB API for duplicate detection during import.
+     */
+    @Column(name = "igdb_id", unique = true)
+    private Long igdbId;
+
     @Column(nullable = false)
     private String title;
 
     @Column(columnDefinition = "TEXT")
     private String description;
+
+    /**
+     * URL of the cover image from IGDB.
+     */
+    @Column(name = "cover_url")
+    private String coverUrl;
 
     @Column(name = "release_date")
     private LocalDate releaseDate;
@@ -194,6 +206,14 @@ public class VideoGame {
         this.id = id;
     }
 
+    public Long getIgdbId() {
+        return igdbId;
+    }
+
+    public void setIgdbId(Long igdbId) {
+        this.igdbId = igdbId;
+    }
+
     public String getTitle() {
         return title;
     }
@@ -208,6 +228,14 @@ public class VideoGame {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getCoverUrl() {
+        return coverUrl;
+    }
+
+    public void setCoverUrl(String coverUrl) {
+        this.coverUrl = coverUrl;
     }
 
     public LocalDate getReleaseDate() {

--- a/api/src/main/java/com/checkpoint/api/mapper/GameMapper.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/GameMapper.java
@@ -1,0 +1,28 @@
+package com.checkpoint.api.mapper;
+
+import com.checkpoint.api.dto.igdb.IgdbGameDto;
+import com.checkpoint.api.entities.VideoGame;
+
+/**
+ * Interface for mapping between IGDB DTOs and local entities.
+ */
+public interface GameMapper {
+
+    /**
+     * Converts an IGDB game DTO to a new VideoGame entity.
+     * Does not persist the entity or resolve relationships.
+     *
+     * @param dto the IGDB game DTO
+     * @return a new VideoGame entity with basic fields populated
+     */
+    VideoGame toEntity(IgdbGameDto dto);
+
+    /**
+     * Updates an existing VideoGame entity with data from an IGDB game DTO.
+     * Does not modify relationships (genres, platforms, companies).
+     *
+     * @param dto the IGDB game DTO
+     * @param entity the existing VideoGame entity to update
+     */
+    void updateEntity(IgdbGameDto dto, VideoGame entity);
+}

--- a/api/src/main/java/com/checkpoint/api/mapper/GameMapperImpl.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/GameMapperImpl.java
@@ -1,0 +1,78 @@
+package com.checkpoint.api.mapper;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.springframework.stereotype.Component;
+
+import com.checkpoint.api.dto.igdb.IgdbGameDto;
+import com.checkpoint.api.entities.VideoGame;
+
+/**
+ * Implementation of {@link GameMapper} for mapping IGDB DTOs to VideoGame entities.
+ */
+@Component
+public class GameMapperImpl implements GameMapper {
+
+    @Override
+    public VideoGame toEntity(IgdbGameDto dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        VideoGame entity = new VideoGame();
+        mapBasicFields(dto, entity);
+        return entity;
+    }
+
+    @Override
+    public void updateEntity(IgdbGameDto dto, VideoGame entity) {
+        if (dto == null || entity == null) {
+            return;
+        }
+
+        mapBasicFields(dto, entity);
+    }
+
+    /**
+     * Maps basic fields from DTO to entity.
+     *
+     * @param dto the source DTO
+     * @param entity the target entity
+     */
+    private void mapBasicFields(IgdbGameDto dto, VideoGame entity) {
+        entity.setIgdbId(dto.id());
+        entity.setTitle(dto.name());
+
+        // Use summary as description, fallback to storyline if summary is null
+        String description = dto.summary();
+        if (description == null || description.isBlank()) {
+            description = dto.storyline();
+        }
+        entity.setDescription(description);
+
+        // Convert Unix timestamp to LocalDate
+        entity.setReleaseDate(convertUnixTimestampToLocalDate(dto.firstReleaseDate()));
+
+        // Set cover URL using the cover_big size
+        if (dto.cover() != null) {
+            entity.setCoverUrl(dto.cover().getCoverBigUrl());
+        }
+    }
+
+    /**
+     * Converts a Unix timestamp (seconds since epoch) to LocalDate.
+     *
+     * @param timestamp the Unix timestamp
+     * @return LocalDate or null if timestamp is null
+     */
+    private LocalDate convertUnixTimestampToLocalDate(Long timestamp) {
+        if (timestamp == null) {
+            return null;
+        }
+        return Instant.ofEpochSecond(timestamp)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/repositories/CompanyRepository.java
+++ b/api/src/main/java/com/checkpoint/api/repositories/CompanyRepository.java
@@ -1,0 +1,24 @@
+package com.checkpoint.api.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.checkpoint.api.entities.Company;
+
+/**
+ * Repository for Company entity.
+ */
+@Repository
+public interface CompanyRepository extends JpaRepository<Company, UUID> {
+
+    /**
+     * Finds a company by its name (case-insensitive).
+     *
+     * @param name the company name
+     * @return Optional containing the company if found
+     */
+    Optional<Company> findByNameIgnoreCase(String name);
+}

--- a/api/src/main/java/com/checkpoint/api/repositories/GenreRepository.java
+++ b/api/src/main/java/com/checkpoint/api/repositories/GenreRepository.java
@@ -1,0 +1,24 @@
+package com.checkpoint.api.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.checkpoint.api.entities.Genre;
+
+/**
+ * Repository for Genre entity.
+ */
+@Repository
+public interface GenreRepository extends JpaRepository<Genre, UUID> {
+
+    /**
+     * Finds a genre by its name (case-insensitive).
+     *
+     * @param name the genre name
+     * @return Optional containing the genre if found
+     */
+    Optional<Genre> findByNameIgnoreCase(String name);
+}

--- a/api/src/main/java/com/checkpoint/api/repositories/PlatformRepository.java
+++ b/api/src/main/java/com/checkpoint/api/repositories/PlatformRepository.java
@@ -1,0 +1,24 @@
+package com.checkpoint.api.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.checkpoint.api.entities.Platform;
+
+/**
+ * Repository for Platform entity.
+ */
+@Repository
+public interface PlatformRepository extends JpaRepository<Platform, UUID> {
+
+    /**
+     * Finds a platform by its name (case-insensitive).
+     *
+     * @param name the platform name
+     * @return Optional containing the platform if found
+     */
+    Optional<Platform> findByNameIgnoreCase(String name);
+}

--- a/api/src/main/java/com/checkpoint/api/repositories/VideoGameRepository.java
+++ b/api/src/main/java/com/checkpoint/api/repositories/VideoGameRepository.java
@@ -1,0 +1,33 @@
+package com.checkpoint.api.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.checkpoint.api.entities.VideoGame;
+
+/**
+ * Repository for VideoGame entity.
+ */
+@Repository
+public interface VideoGameRepository extends JpaRepository<VideoGame, UUID> {
+
+    /**
+     * Finds a video game by its IGDB external ID.
+     * Used for duplicate detection during import.
+     *
+     * @param igdbId the IGDB game ID
+     * @return Optional containing the video game if found
+     */
+    Optional<VideoGame> findByIgdbId(Long igdbId);
+
+    /**
+     * Checks if a video game with the given IGDB ID exists.
+     *
+     * @param igdbId the IGDB game ID
+     * @return true if exists, false otherwise
+     */
+    boolean existsByIgdbId(Long igdbId);
+}

--- a/api/src/main/java/com/checkpoint/api/services/GameImportService.java
+++ b/api/src/main/java/com/checkpoint/api/services/GameImportService.java
@@ -1,0 +1,50 @@
+package com.checkpoint.api.services;
+
+import java.util.List;
+
+import com.checkpoint.api.entities.VideoGame;
+
+/**
+ * Service interface for importing games from external APIs.
+ */
+public interface GameImportService {
+
+    /**
+     * Imports recently released games from IGDB.
+     *
+     * @param limit maximum number of games to import
+     * @return list of imported/updated video games
+     */
+    List<VideoGame> importRecentlyReleasedGames(int limit);
+
+    /**
+     * Imports games by their IGDB IDs.
+     *
+     * @param igdbIds list of IGDB game IDs to import
+     * @return list of imported/updated video games
+     */
+    List<VideoGame> importGamesByIds(List<Long> igdbIds);
+
+    /**
+     * Searches and imports games matching a query.
+     *
+     * @param query the search query
+     * @param limit maximum number of games to import
+     * @return list of imported/updated video games
+     */
+    List<VideoGame> searchAndImportGames(String query, int limit);
+
+    /**
+     * Imports top rated games from IGDB.
+     *
+     * @param limit maximum number of games to import
+     * @param minRatingCount minimum number of ratings required
+     * @return list of imported/updated video games
+     */
+    List<VideoGame> importTopRatedGames(int limit, int minRatingCount);
+
+    /**
+     * Result object containing import statistics.
+     */
+    record ImportResult(int created, int updated, int failed, List<VideoGame> games) {}
+}

--- a/api/src/main/java/com/checkpoint/api/services/GameImportServiceImpl.java
+++ b/api/src/main/java/com/checkpoint/api/services/GameImportServiceImpl.java
@@ -1,0 +1,256 @@
+package com.checkpoint.api.services;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.checkpoint.api.client.IgdbApiClient;
+import com.checkpoint.api.dto.igdb.IgdbCompanyDto;
+import com.checkpoint.api.dto.igdb.IgdbGameDto;
+import com.checkpoint.api.dto.igdb.IgdbGenreDto;
+import com.checkpoint.api.dto.igdb.IgdbInvolvedCompanyDto;
+import com.checkpoint.api.dto.igdb.IgdbPlatformDto;
+import com.checkpoint.api.entities.Company;
+import com.checkpoint.api.entities.Genre;
+import com.checkpoint.api.entities.Platform;
+import com.checkpoint.api.entities.VideoGame;
+import com.checkpoint.api.mapper.GameMapper;
+import com.checkpoint.api.repositories.CompanyRepository;
+import com.checkpoint.api.repositories.GenreRepository;
+import com.checkpoint.api.repositories.PlatformRepository;
+import com.checkpoint.api.repositories.VideoGameRepository;
+
+/**
+ * Implementation of {@link GameImportService}.
+ * Handles the orchestration of game imports from IGDB with:
+ * - Duplicate detection and update (upsert behavior)
+ * - Relationship management (genres, platforms, companies)
+ * - Rate limiting is handled by the IgdbApiClient
+ */
+@Service
+@Transactional
+public class GameImportServiceImpl implements GameImportService {
+
+    private static final Logger log = LoggerFactory.getLogger(GameImportServiceImpl.class);
+
+    private final IgdbApiClient igdbApiClient;
+    private final GameMapper gameMapper;
+    private final VideoGameRepository videoGameRepository;
+    private final GenreRepository genreRepository;
+    private final PlatformRepository platformRepository;
+    private final CompanyRepository companyRepository;
+
+    public GameImportServiceImpl(
+            IgdbApiClient igdbApiClient,
+            GameMapper gameMapper,
+            VideoGameRepository videoGameRepository,
+            GenreRepository genreRepository,
+            PlatformRepository platformRepository,
+            CompanyRepository companyRepository) {
+        this.igdbApiClient = igdbApiClient;
+        this.gameMapper = gameMapper;
+        this.videoGameRepository = videoGameRepository;
+        this.genreRepository = genreRepository;
+        this.platformRepository = platformRepository;
+        this.companyRepository = companyRepository;
+    }
+
+    @Override
+    public List<VideoGame> importRecentlyReleasedGames(int limit) {
+        log.info("Importing {} recently released games", limit);
+        List<IgdbGameDto> games = igdbApiClient.fetchRecentlyReleasedGames(limit);
+        return importGames(games);
+    }
+
+    @Override
+    public List<VideoGame> importGamesByIds(List<Long> igdbIds) {
+        log.info("Importing {} games by IDs", igdbIds.size());
+        List<IgdbGameDto> games = igdbApiClient.fetchGamesByIds(igdbIds);
+        return importGames(games);
+    }
+
+    @Override
+    public List<VideoGame> searchAndImportGames(String query, int limit) {
+        log.info("Searching and importing games matching '{}'", query);
+        List<IgdbGameDto> games = igdbApiClient.searchGames(query, limit);
+        return importGames(games);
+    }
+
+    @Override
+    public List<VideoGame> importTopRatedGames(int limit, int minRatingCount) {
+        log.info("Importing top {} rated games (min {} ratings)", limit, minRatingCount);
+        List<IgdbGameDto> games = igdbApiClient.fetchTopRatedGames(limit, minRatingCount);
+        return importGames(games);
+    }
+
+    /**
+     * Imports a list of games, handling duplicates and relationships.
+     *
+     * @param games list of IGDB game DTOs to import
+     * @return list of persisted VideoGame entities
+     */
+    private List<VideoGame> importGames(List<IgdbGameDto> games) {
+        List<VideoGame> result = new ArrayList<>();
+        int created = 0;
+        int updated = 0;
+
+        for (IgdbGameDto dto : games) {
+            try {
+                VideoGame videoGame = importSingleGame(dto);
+                result.add(videoGame);
+
+                if (videoGame.getId() == null) {
+                    created++;
+                } else {
+                    updated++;
+                }
+            } catch (Exception e) {
+                log.error("Failed to import game '{}' (IGDB ID: {}): {}",
+                        dto.name(), dto.id(), e.getMessage(), e);
+            }
+        }
+
+        log.info("Import completed: {} created, {} updated, {} failed out of {} total",
+                created, updated, games.size() - created - updated, games.size());
+
+        return result;
+    }
+
+    /**
+     * Imports or updates a single game with all its relationships.
+     *
+     * @param dto the IGDB game DTO
+     * @return the persisted VideoGame entity
+     */
+    private VideoGame importSingleGame(IgdbGameDto dto) {
+        // Check for existing game by IGDB ID (duplicate handling)
+        Optional<VideoGame> existingGame = videoGameRepository.findByIgdbId(dto.id());
+
+        VideoGame videoGame;
+        if (existingGame.isPresent()) {
+            log.debug("Updating existing game: {} (IGDB ID: {})", dto.name(), dto.id());
+            videoGame = existingGame.get();
+            gameMapper.updateEntity(dto, videoGame);
+        } else {
+            log.debug("Creating new game: {} (IGDB ID: {})", dto.name(), dto.id());
+            videoGame = gameMapper.toEntity(dto);
+        }
+
+        // Resolve and set relationships
+        resolveAndSetGenres(dto, videoGame);
+        resolveAndSetPlatforms(dto, videoGame);
+        resolveAndSetCompanies(dto, videoGame);
+
+        return videoGameRepository.save(videoGame);
+    }
+
+    /**
+     * Resolves genre entities (creating them if necessary) and associates them with the game.
+     */
+    private void resolveAndSetGenres(IgdbGameDto dto, VideoGame videoGame) {
+        if (dto.genres() == null || dto.genres().isEmpty()) {
+            return;
+        }
+
+        Set<Genre> genres = new HashSet<>();
+        for (IgdbGenreDto genreDto : dto.genres()) {
+            Genre genre = findOrCreateGenre(genreDto.name());
+            genres.add(genre);
+        }
+
+        // Clear existing genres and add new ones
+        videoGame.getGenres().clear();
+        for (Genre genre : genres) {
+            videoGame.addGenre(genre);
+        }
+    }
+
+    /**
+     * Resolves platform entities (creating them if necessary) and associates them with the game.
+     */
+    private void resolveAndSetPlatforms(IgdbGameDto dto, VideoGame videoGame) {
+        if (dto.platforms() == null || dto.platforms().isEmpty()) {
+            return;
+        }
+
+        Set<Platform> platforms = new HashSet<>();
+        for (IgdbPlatformDto platformDto : dto.platforms()) {
+            Platform platform = findOrCreatePlatform(platformDto.name());
+            platforms.add(platform);
+        }
+
+        // Clear existing platforms and add new ones
+        videoGame.getPlatforms().clear();
+        for (Platform platform : platforms) {
+            videoGame.addPlatform(platform);
+        }
+    }
+
+    /**
+     * Resolves company entities (creating them if necessary) and associates them with the game.
+     * Only includes developers and publishers.
+     */
+    private void resolveAndSetCompanies(IgdbGameDto dto, VideoGame videoGame) {
+        if (dto.involvedCompanies() == null || dto.involvedCompanies().isEmpty()) {
+            return;
+        }
+
+        Set<Company> companies = new HashSet<>();
+        for (IgdbInvolvedCompanyDto involvement : dto.involvedCompanies()) {
+            // Only include developers and publishers
+            if (involvement.developer() || involvement.publisher()) {
+                IgdbCompanyDto companyDto = involvement.company();
+                if (companyDto != null && companyDto.name() != null) {
+                    Company company = findOrCreateCompany(companyDto.name(), companyDto.description());
+                    companies.add(company);
+                }
+            }
+        }
+
+        // Clear existing companies and add new ones
+        videoGame.getCompanies().clear();
+        for (Company company : companies) {
+            videoGame.addCompany(company);
+        }
+    }
+
+    /**
+     * Finds an existing genre by name or creates a new one.
+     */
+    private Genre findOrCreateGenre(String name) {
+        return genreRepository.findByNameIgnoreCase(name)
+                .orElseGet(() -> {
+                    log.debug("Creating new genre: {}", name);
+                    return genreRepository.save(new Genre(name));
+                });
+    }
+
+    /**
+     * Finds an existing platform by name or creates a new one.
+     */
+    private Platform findOrCreatePlatform(String name) {
+        return platformRepository.findByNameIgnoreCase(name)
+                .orElseGet(() -> {
+                    log.debug("Creating new platform: {}", name);
+                    return platformRepository.save(new Platform(name));
+                });
+    }
+
+    /**
+     * Finds an existing company by name or creates a new one.
+     */
+    private Company findOrCreateCompany(String name, String description) {
+        return companyRepository.findByNameIgnoreCase(name)
+                .orElseGet(() -> {
+                    log.debug("Creating new company: {}", name);
+                    return companyRepository.save(new Company(name, description));
+                });
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/client/RateLimiterTest.java
+++ b/api/src/test/java/com/checkpoint/api/client/RateLimiterTest.java
@@ -1,0 +1,87 @@
+package com.checkpoint.api.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+
+/**
+ * Unit tests for rate limiting behavior.
+ * Tests that the rate limiter correctly throttles requests.
+ */
+class RateLimiterTest {
+
+    @Test
+    @DisplayName("RateLimiter should throttle requests to 1 per second")
+    void rateLimiter_shouldThrottleRequests() {
+        // Given - A rate limiter configured for 1 request per second
+        RateLimiterConfig config = RateLimiterConfig.custom()
+                .limitRefreshPeriod(Duration.ofSeconds(1))
+                .limitForPeriod(1)
+                .timeoutDuration(Duration.ofSeconds(5))
+                .build();
+
+        RateLimiterRegistry registry = RateLimiterRegistry.of(config);
+        RateLimiter rateLimiter = registry.rateLimiter("testLimiter");
+
+        // When - Making 3 requests
+        Instant start = Instant.now();
+
+        // First request should be immediate
+        RateLimiter.waitForPermission(rateLimiter);
+        Instant afterFirst = Instant.now();
+
+        // Second request should wait
+        RateLimiter.waitForPermission(rateLimiter);
+        Instant afterSecond = Instant.now();
+
+        // Third request should wait
+        RateLimiter.waitForPermission(rateLimiter);
+        Instant afterThird = Instant.now();
+
+        // Then
+        // First request should be nearly instant
+        Duration firstDuration = Duration.between(start, afterFirst);
+        assertThat(firstDuration.toMillis()).isLessThan(100);
+
+        // Total time for 3 requests should be at least 2 seconds (2 waits)
+        Duration totalDuration = Duration.between(start, afterThird);
+        assertThat(totalDuration.toMillis()).isGreaterThanOrEqualTo(1900);
+    }
+
+    @Test
+    @DisplayName("RateLimiter should allow burst after refresh period")
+    void rateLimiter_shouldAllowBurstAfterRefresh() throws InterruptedException {
+        // Given
+        RateLimiterConfig config = RateLimiterConfig.custom()
+                .limitRefreshPeriod(Duration.ofMillis(500))
+                .limitForPeriod(1)
+                .timeoutDuration(Duration.ofSeconds(5))
+                .build();
+
+        RateLimiterRegistry registry = RateLimiterRegistry.of(config);
+        RateLimiter rateLimiter = registry.rateLimiter("testLimiter2");
+
+        // When - First request
+        RateLimiter.waitForPermission(rateLimiter);
+
+        // Wait for refresh
+        Thread.sleep(600);
+
+        // Second request after refresh
+        Instant beforeSecond = Instant.now();
+        RateLimiter.waitForPermission(rateLimiter);
+        Instant afterSecond = Instant.now();
+
+        // Then - Second request should be nearly instant after refresh
+        Duration secondDuration = Duration.between(beforeSecond, afterSecond);
+        assertThat(secondDuration.toMillis()).isLessThan(100);
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/mapper/GameMapperImplTest.java
+++ b/api/src/test/java/com/checkpoint/api/mapper/GameMapperImplTest.java
@@ -1,0 +1,169 @@
+package com.checkpoint.api.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.checkpoint.api.dto.igdb.IgdbCoverDto;
+import com.checkpoint.api.dto.igdb.IgdbGameDto;
+import com.checkpoint.api.dto.igdb.IgdbGenreDto;
+import com.checkpoint.api.entities.VideoGame;
+
+/**
+ * Unit tests for {@link GameMapperImpl}.
+ */
+class GameMapperImplTest {
+
+    private GameMapperImpl gameMapper;
+
+    @BeforeEach
+    void setUp() {
+        gameMapper = new GameMapperImpl();
+    }
+
+    @Test
+    @DisplayName("toEntity should map basic fields correctly")
+    void toEntity_shouldMapBasicFields() {
+        // Given
+        IgdbCoverDto cover = new IgdbCoverDto(
+                1L, "co1wyy", "//images.igdb.com/igdb/image/upload/t_thumb/co1wyy.jpg",
+                264, 374, false, false
+        );
+
+        IgdbGameDto dto = new IgdbGameDto(
+                1942L,
+                "The Witcher 3: Wild Hunt",
+                "the-witcher-3-wild-hunt",
+                "An RPG game",
+                "Geralt's story",
+                1431993600L, // May 19, 2015
+                92.5, 1250, 93.8, 85, 93.15, 1335,
+                cover,
+                List.of(new IgdbGenreDto(12L, "RPG", "rpg", "url")),
+                null, null, null, null, null, null, null,
+                null, null, null, null, "https://igdb.com/game"
+        );
+
+        // When
+        VideoGame entity = gameMapper.toEntity(dto);
+
+        // Then
+        assertThat(entity).isNotNull();
+        assertThat(entity.getIgdbId()).isEqualTo(1942L);
+        assertThat(entity.getTitle()).isEqualTo("The Witcher 3: Wild Hunt");
+        assertThat(entity.getDescription()).isEqualTo("An RPG game");
+        assertThat(entity.getReleaseDate()).isEqualTo(LocalDate.of(2015, 5, 19));
+        assertThat(entity.getCoverUrl()).isEqualTo("https://images.igdb.com/igdb/image/upload/t_cover_big/co1wyy.jpg");
+    }
+
+    @Test
+    @DisplayName("toEntity should use storyline when summary is null")
+    void toEntity_shouldUseStorylineWhenSummaryIsNull() {
+        // Given
+        IgdbGameDto dto = new IgdbGameDto(
+                1L, "Test Game", "test-game",
+                null, // summary is null
+                "This is the storyline",
+                null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null
+        );
+
+        // When
+        VideoGame entity = gameMapper.toEntity(dto);
+
+        // Then
+        assertThat(entity.getDescription()).isEqualTo("This is the storyline");
+    }
+
+    @Test
+    @DisplayName("toEntity should handle null release date")
+    void toEntity_shouldHandleNullReleaseDate() {
+        // Given
+        IgdbGameDto dto = new IgdbGameDto(
+                1L, "Test Game", "test-game",
+                "Summary", null,
+                null, // no release date
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null
+        );
+
+        // When
+        VideoGame entity = gameMapper.toEntity(dto);
+
+        // Then
+        assertThat(entity.getReleaseDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("toEntity should return null for null input")
+    void toEntity_shouldReturnNullForNullInput() {
+        // When
+        VideoGame entity = gameMapper.toEntity(null);
+
+        // Then
+        assertThat(entity).isNull();
+    }
+
+    @Test
+    @DisplayName("updateEntity should update existing entity")
+    void updateEntity_shouldUpdateExistingEntity() {
+        // Given
+        VideoGame existingEntity = new VideoGame();
+        existingEntity.setTitle("Old Title");
+        existingEntity.setDescription("Old Description");
+
+        IgdbGameDto dto = new IgdbGameDto(
+                123L, "New Title", "new-title",
+                "New Description", null,
+                1609459200L, // Jan 1, 2021
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null
+        );
+
+        // When
+        gameMapper.updateEntity(dto, existingEntity);
+
+        // Then
+        assertThat(existingEntity.getIgdbId()).isEqualTo(123L);
+        assertThat(existingEntity.getTitle()).isEqualTo("New Title");
+        assertThat(existingEntity.getDescription()).isEqualTo("New Description");
+        assertThat(existingEntity.getReleaseDate()).isEqualTo(LocalDate.of(2021, 1, 1));
+    }
+
+    @Test
+    @DisplayName("updateEntity should handle null dto gracefully")
+    void updateEntity_shouldHandleNullDtoGracefully() {
+        // Given
+        VideoGame existingEntity = new VideoGame();
+        existingEntity.setTitle("Original Title");
+
+        // When
+        gameMapper.updateEntity(null, existingEntity);
+
+        // Then - entity unchanged
+        assertThat(existingEntity.getTitle()).isEqualTo("Original Title");
+    }
+
+    @Test
+    @DisplayName("updateEntity should handle null entity gracefully")
+    void updateEntity_shouldHandleNullEntityGracefully() {
+        // Given
+        IgdbGameDto dto = new IgdbGameDto(
+                1L, "Test", "test", null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null
+        );
+
+        // When / Then - should not throw
+        gameMapper.updateEntity(dto, null);
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/services/GameImportServiceImplTest.java
+++ b/api/src/test/java/com/checkpoint/api/services/GameImportServiceImplTest.java
@@ -1,0 +1,286 @@
+package com.checkpoint.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.checkpoint.api.client.IgdbApiClient;
+import com.checkpoint.api.dto.igdb.IgdbCompanyDto;
+import com.checkpoint.api.dto.igdb.IgdbCoverDto;
+import com.checkpoint.api.dto.igdb.IgdbGameDto;
+import com.checkpoint.api.dto.igdb.IgdbGenreDto;
+import com.checkpoint.api.dto.igdb.IgdbInvolvedCompanyDto;
+import com.checkpoint.api.dto.igdb.IgdbPlatformDto;
+import com.checkpoint.api.entities.Company;
+import com.checkpoint.api.entities.Genre;
+import com.checkpoint.api.entities.Platform;
+import com.checkpoint.api.entities.VideoGame;
+import com.checkpoint.api.mapper.GameMapper;
+import com.checkpoint.api.repositories.CompanyRepository;
+import com.checkpoint.api.repositories.GenreRepository;
+import com.checkpoint.api.repositories.PlatformRepository;
+import com.checkpoint.api.repositories.VideoGameRepository;
+
+/**
+ * Unit tests for {@link GameImportServiceImpl}.
+ */
+@ExtendWith(MockitoExtension.class)
+class GameImportServiceImplTest {
+
+    @Mock
+    private IgdbApiClient igdbApiClient;
+
+    @Mock
+    private GameMapper gameMapper;
+
+    @Mock
+    private VideoGameRepository videoGameRepository;
+
+    @Mock
+    private GenreRepository genreRepository;
+
+    @Mock
+    private PlatformRepository platformRepository;
+
+    @Mock
+    private CompanyRepository companyRepository;
+
+    private GameImportServiceImpl gameImportService;
+
+    @BeforeEach
+    void setUp() {
+        gameImportService = new GameImportServiceImpl(
+                igdbApiClient,
+                gameMapper,
+                videoGameRepository,
+                genreRepository,
+                platformRepository,
+                companyRepository
+        );
+    }
+
+    @Test
+    @DisplayName("importRecentlyReleasedGames should create new games")
+    void importRecentlyReleasedGames_shouldCreateNewGames() {
+        // Given
+        IgdbGameDto dto = createSampleGameDto(1942L, "The Witcher 3");
+        List<IgdbGameDto> games = List.of(dto);
+
+        VideoGame newEntity = new VideoGame();
+        newEntity.setIgdbId(1942L);
+        newEntity.setTitle("The Witcher 3");
+
+        when(igdbApiClient.fetchRecentlyReleasedGames(10)).thenReturn(games);
+        when(videoGameRepository.findByIgdbId(1942L)).thenReturn(Optional.empty());
+        when(gameMapper.toEntity(dto)).thenReturn(newEntity);
+        when(genreRepository.findByNameIgnoreCase("RPG")).thenReturn(Optional.of(new Genre("RPG")));
+        when(platformRepository.findByNameIgnoreCase("PC")).thenReturn(Optional.of(new Platform("PC")));
+        when(companyRepository.findByNameIgnoreCase("CD Projekt RED")).thenReturn(Optional.of(new Company("CD Projekt RED")));
+        when(videoGameRepository.save(any(VideoGame.class))).thenReturn(newEntity);
+
+        // When
+        List<VideoGame> result = gameImportService.importRecentlyReleasedGames(10);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(gameMapper).toEntity(dto);
+        verify(gameMapper, never()).updateEntity(any(), any());
+        verify(videoGameRepository).save(any(VideoGame.class));
+    }
+
+    @Test
+    @DisplayName("importRecentlyReleasedGames should update existing games (duplicate handling)")
+    void importRecentlyReleasedGames_shouldUpdateExistingGames() {
+        // Given
+        IgdbGameDto dto = createSampleGameDto(1942L, "The Witcher 3: Updated");
+        List<IgdbGameDto> games = List.of(dto);
+
+        VideoGame existingEntity = new VideoGame();
+        existingEntity.setId(UUID.randomUUID());
+        existingEntity.setIgdbId(1942L);
+        existingEntity.setTitle("The Witcher 3");
+
+        when(igdbApiClient.fetchRecentlyReleasedGames(10)).thenReturn(games);
+        when(videoGameRepository.findByIgdbId(1942L)).thenReturn(Optional.of(existingEntity));
+        when(genreRepository.findByNameIgnoreCase("RPG")).thenReturn(Optional.of(new Genre("RPG")));
+        when(platformRepository.findByNameIgnoreCase("PC")).thenReturn(Optional.of(new Platform("PC")));
+        when(companyRepository.findByNameIgnoreCase("CD Projekt RED")).thenReturn(Optional.of(new Company("CD Projekt RED")));
+        when(videoGameRepository.save(any(VideoGame.class))).thenReturn(existingEntity);
+
+        // When
+        List<VideoGame> result = gameImportService.importRecentlyReleasedGames(10);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(gameMapper, never()).toEntity(any());
+        verify(gameMapper).updateEntity(dto, existingEntity);
+        verify(videoGameRepository).save(existingEntity);
+    }
+
+    @Test
+    @DisplayName("importRecentlyReleasedGames should create genres if not found")
+    void importRecentlyReleasedGames_shouldCreateGenresIfNotFound() {
+        // Given
+        IgdbGameDto dto = createSampleGameDto(1L, "Test Game");
+        List<IgdbGameDto> games = List.of(dto);
+
+        VideoGame newEntity = new VideoGame();
+        Genre newGenre = new Genre("RPG");
+
+        when(igdbApiClient.fetchRecentlyReleasedGames(10)).thenReturn(games);
+        when(videoGameRepository.findByIgdbId(1L)).thenReturn(Optional.empty());
+        when(gameMapper.toEntity(dto)).thenReturn(newEntity);
+        when(genreRepository.findByNameIgnoreCase("RPG")).thenReturn(Optional.empty());
+        when(genreRepository.save(any(Genre.class))).thenReturn(newGenre);
+        when(platformRepository.findByNameIgnoreCase("PC")).thenReturn(Optional.of(new Platform("PC")));
+        when(companyRepository.findByNameIgnoreCase("CD Projekt RED")).thenReturn(Optional.of(new Company("CD Projekt RED")));
+        when(videoGameRepository.save(any(VideoGame.class))).thenReturn(newEntity);
+
+        // When
+        gameImportService.importRecentlyReleasedGames(10);
+
+        // Then
+        ArgumentCaptor<Genre> genreCaptor = ArgumentCaptor.forClass(Genre.class);
+        verify(genreRepository).save(genreCaptor.capture());
+        assertThat(genreCaptor.getValue().getName()).isEqualTo("RPG");
+    }
+
+    @Test
+    @DisplayName("searchAndImportGames should use search API")
+    void searchAndImportGames_shouldUseSearchApi() {
+        // Given
+        IgdbGameDto dto = createSampleGameDto(1L, "Test Game");
+        List<IgdbGameDto> games = List.of(dto);
+        VideoGame newEntity = new VideoGame();
+
+        when(igdbApiClient.searchGames("witcher", 5)).thenReturn(games);
+        when(videoGameRepository.findByIgdbId(1L)).thenReturn(Optional.empty());
+        when(gameMapper.toEntity(dto)).thenReturn(newEntity);
+        when(genreRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Genre("RPG")));
+        when(platformRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Platform("PC")));
+        when(companyRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Company("Company")));
+        when(videoGameRepository.save(any())).thenReturn(newEntity);
+
+        // When
+        List<VideoGame> result = gameImportService.searchAndImportGames("witcher", 5);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(igdbApiClient).searchGames("witcher", 5);
+    }
+
+    @Test
+    @DisplayName("importGamesByIds should use fetch by IDs API")
+    void importGamesByIds_shouldUseFetchByIdsApi() {
+        // Given
+        List<Long> ids = List.of(1L, 2L);
+        IgdbGameDto dto1 = createSampleGameDto(1L, "Game 1");
+        IgdbGameDto dto2 = createSampleGameDto(2L, "Game 2");
+        List<IgdbGameDto> games = List.of(dto1, dto2);
+
+        when(igdbApiClient.fetchGamesByIds(ids)).thenReturn(games);
+        when(videoGameRepository.findByIgdbId(any())).thenReturn(Optional.empty());
+        when(gameMapper.toEntity(any())).thenReturn(new VideoGame());
+        when(genreRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Genre("RPG")));
+        when(platformRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Platform("PC")));
+        when(companyRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Company("Company")));
+        when(videoGameRepository.save(any())).thenReturn(new VideoGame());
+
+        // When
+        List<VideoGame> result = gameImportService.importGamesByIds(ids);
+
+        // Then
+        assertThat(result).hasSize(2);
+        verify(igdbApiClient).fetchGamesByIds(ids);
+        verify(videoGameRepository, times(2)).save(any());
+    }
+
+    @Test
+    @DisplayName("importTopRatedGames should use top rated API")
+    void importTopRatedGames_shouldUseTopRatedApi() {
+        // Given
+        IgdbGameDto dto = createSampleGameDto(1L, "Top Game");
+        List<IgdbGameDto> games = List.of(dto);
+        VideoGame newEntity = new VideoGame();
+
+        when(igdbApiClient.fetchTopRatedGames(20, 100)).thenReturn(games);
+        when(videoGameRepository.findByIgdbId(1L)).thenReturn(Optional.empty());
+        when(gameMapper.toEntity(dto)).thenReturn(newEntity);
+        when(genreRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Genre("RPG")));
+        when(platformRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Platform("PC")));
+        when(companyRepository.findByNameIgnoreCase(anyString())).thenReturn(Optional.of(new Company("Company")));
+        when(videoGameRepository.save(any())).thenReturn(newEntity);
+
+        // When
+        List<VideoGame> result = gameImportService.importTopRatedGames(20, 100);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(igdbApiClient).fetchTopRatedGames(20, 100);
+    }
+
+    /**
+     * Creates a sample IgdbGameDto for testing.
+     */
+    private IgdbGameDto createSampleGameDto(Long id, String name) {
+        IgdbCoverDto cover = new IgdbCoverDto(
+                1L, "co1wyy", "//images.igdb.com/igdb/image/upload/t_thumb/co1wyy.jpg",
+                264, 374, false, false
+        );
+
+        IgdbGenreDto genre = new IgdbGenreDto(12L, "RPG", "rpg", "url");
+
+        IgdbPlatformDto platform = new IgdbPlatformDto(
+                6L, "PC", "win", "PC", null, null, null, null, "url"
+        );
+
+        IgdbCompanyDto company = new IgdbCompanyDto(
+                908L, "CD Projekt RED", "cd-projekt-red", "Polish developer",
+                null, null, "url", 616
+        );
+
+        IgdbInvolvedCompanyDto involvedCompany = new IgdbInvolvedCompanyDto(
+                1L, company, true, true, false, false
+        );
+
+        return new IgdbGameDto(
+                id,
+                name,
+                name.toLowerCase().replace(" ", "-"),
+                "Summary of " + name,
+                null,
+                1431993600L,
+                92.5, 1250, 93.8, 85, 93.15, 1335,
+                cover,
+                List.of(genre),
+                List.of(platform),
+                List.of(involvedCompany),
+                null,  // screenshots
+                null,  // similarGames
+                null,  // gameModes
+                null,  // themes
+                null,  // playerPerspectives
+                null,  // parentGame
+                null,  // dlcs
+                null,  // expansions
+                null,  // versionTitle
+                "url"
+        );
+    }
+}


### PR DESCRIPTION
- Add Resilience4j RateLimiter (1 req/sec) to IgdbApiClient
- Create GameMapper interface for DTO to entity conversion
- Implement GameImportService with upsert duplicate handling
- Add igdbId and coverUrl fields to VideoGame entity
- Create repositories for VideoGame, Genre, Platform, Company
- Add unit tests for mapper, service, and rate limiter