### PR TITLE
feat(api): implement public game catalog endpoints with pagination [T…

### DIFF
--- a/api/bruno/bruno.json
+++ b/api/bruno/bruno.json
@@ -1,0 +1,6 @@
+{
+	"version": "1",
+	"name": "Checkpoint API",
+	"type": "collection",
+	"ignore": ["node_modules", ".git"]
+}

--- a/api/bruno/environments/local.bru
+++ b/api/bruno/environments/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://localhost:8080
+}

--- a/api/bruno/games/Get Game - Not Found.bru
+++ b/api/bruno/games/Get Game - Not Found.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Game - Not Found
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/games/00000000-0000-0000-0000-000000000000
+  body: none
+  auth: none
+}
+
+docs {
+  # Get Game - Not Found
+
+  Example: Request for a non-existent game ID.
+
+  Expected response: 404 Not Found
+}

--- a/api/bruno/games/Get Game by ID.bru
+++ b/api/bruno/games/Get Game by ID.bru
@@ -1,0 +1,63 @@
+meta {
+  name: Get Game by ID
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/games/:id
+  body: none
+  auth: none
+}
+
+params:path {
+  id: 550e8400-e29b-41d4-a716-446655440000
+}
+
+docs {
+  # Get Game by ID
+
+  Retrieves detailed information about a specific game.
+
+  ## Path Parameters
+
+  | Parameter | Description |
+  |-----------|-------------|
+  | id | UUID of the game |
+
+  ## Response (200 OK)
+
+  ```json
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "The Witcher 3: Wild Hunt",
+    "description": "An epic RPG adventure...",
+    "coverUrl": "https://images.igdb.com/...",
+    "releaseDate": "2015-05-19",
+    "averageRating": 4.8,
+    "ratingCount": 1500,
+    "genres": [
+      { "id": "uuid", "name": "RPG" },
+      { "id": "uuid", "name": "Adventure" }
+    ],
+    "platforms": [
+      { "id": "uuid", "name": "PC (Microsoft Windows)" },
+      { "id": "uuid", "name": "PlayStation 4" }
+    ],
+    "companies": [
+      { "id": "uuid", "name": "CD Projekt RED" }
+    ]
+  }
+  ```
+
+  ## Error Response (404 Not Found)
+
+  ```json
+  {
+    "status": 404,
+    "error": "Not Found",
+    "message": "Game not found with ID: 550e8400-e29b-41d4-a716-446655440000",
+    "timestamp": "2025-01-15T10:30:00"
+  }
+  ```
+}

--- a/api/bruno/games/Get Games (Paginated).bru
+++ b/api/bruno/games/Get Games (Paginated).bru
@@ -1,0 +1,65 @@
+meta {
+  name: Get Games (Paginated)
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/games
+  body: none
+  auth: none
+}
+
+params:query {
+  ~page: 0
+  ~size: 20
+  ~sort: releaseDate,desc
+}
+
+docs {
+  # Get Games (Paginated)
+
+  Retrieves a paginated list of games from the catalog.
+
+  ## Query Parameters
+
+  | Parameter | Default | Description |
+  |-----------|---------|-------------|
+  | page | 0 | Page number (0-based) |
+  | size | 20 | Number of items per page (max 100) |
+  | sort | releaseDate,desc | Sort field and direction |
+
+  ## Sort Options
+
+  - `releaseDate,desc` - Newest first
+  - `releaseDate,asc` - Oldest first
+  - `title,asc` - Alphabetical A-Z
+  - `title,desc` - Alphabetical Z-A
+
+  ## Response
+
+  ```json
+  {
+    "content": [
+      {
+        "id": "uuid",
+        "title": "Game Title",
+        "coverUrl": "https://...",
+        "releaseDate": "2025-01-15",
+        "averageRating": 4.5,
+        "ratingCount": 100
+      }
+    ],
+    "metadata": {
+      "page": 0,
+      "size": 20,
+      "totalElements": 150,
+      "totalPages": 8,
+      "first": true,
+      "last": false,
+      "hasNext": true,
+      "hasPrevious": false
+    }
+  }
+  ```
+}

--- a/api/bruno/games/Get Games - Page 2.bru
+++ b/api/bruno/games/Get Games - Page 2.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get Games - Page 2
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/games?page=1&size=10&sort=title,asc
+  body: none
+  auth: none
+}
+
+docs {
+  # Get Games - Page 2
+
+  Example: Fetching the second page with 10 items, sorted by title.
+}

--- a/api/src/main/java/com/checkpoint/api/config/SecurityConfigPlaceholder.java
+++ b/api/src/main/java/com/checkpoint/api/config/SecurityConfigPlaceholder.java
@@ -1,0 +1,40 @@
+package com.checkpoint.api.config;
+
+/**
+ * Security configuration placeholder.
+ *
+ * Note: Spring Security is not currently configured in this project.
+ * When Spring Security is added to the dependencies, this class should be updated
+ * to configure the SecurityFilterChain.
+ *
+ * Public endpoints that should remain accessible without authentication:
+ * - GET /api/games (game catalog with pagination)
+ * - GET /api/games/{id} (game details)
+ *
+ * Example configuration when Spring Security is added:
+ *
+ * <pre>
+ * {@code
+ * @Configuration
+ * @EnableWebSecurity
+ * public class SecurityConfig {
+ *
+ *     @Bean
+ *     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+ *         return http
+ *             .csrf(csrf -> csrf.disable())
+ *             .authorizeHttpRequests(auth -> auth
+ *                 // Public endpoints
+ *                 .requestMatchers(HttpMethod.GET, "/api/games/**").permitAll()
+ *                 // Protected endpoints
+ *                 .anyRequest().authenticated()
+ *             )
+ *             .build();
+ *     }
+ * }
+ * }
+ * </pre>
+ */
+public class SecurityConfigPlaceholder {
+    // Placeholder class - no implementation needed until Spring Security is added
+}

--- a/api/src/main/java/com/checkpoint/api/controllers/GameController.java
+++ b/api/src/main/java/com/checkpoint/api/controllers/GameController.java
@@ -1,0 +1,114 @@
+package com.checkpoint.api.controllers;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.checkpoint.api.dto.catalog.GameCardDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto;
+import com.checkpoint.api.dto.catalog.PagedResponseDto;
+import com.checkpoint.api.services.GameCatalogService;
+
+/**
+ * REST controller for public game catalog endpoints.
+ * Provides paginated access to the game catalog and game details.
+ */
+@RestController
+@RequestMapping("/api/games")
+public class GameController {
+
+    private static final Logger log = LoggerFactory.getLogger(GameController.class);
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+    private static final String DEFAULT_SORT = "releaseDate,desc";
+
+    private final GameCatalogService gameCatalogService;
+
+    public GameController(GameCatalogService gameCatalogService) {
+        this.gameCatalogService = gameCatalogService;
+    }
+
+    /**
+     * Retrieves a paginated list of games.
+     *
+     * @param page the page number (0-based, default 0)
+     * @param size the page size (default 20, max 100)
+     * @param sort the sort criteria (e.g., "releaseDate,desc" or "title,asc")
+     * @return paginated list of game cards
+     */
+    @GetMapping
+    public ResponseEntity<PagedResponseDto<GameCardDto>> getGames(
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size,
+            @RequestParam(defaultValue = DEFAULT_SORT) String sort) {
+
+        log.info("GET /api/games - page: {}, size: {}, sort: {}", page, size, sort);
+
+        // Validate and sanitize inputs
+        int validatedSize = Math.min(Math.max(1, size), MAX_SIZE);
+        int validatedPage = Math.max(0, page);
+
+        Pageable pageable = createPageable(validatedPage, validatedSize, sort);
+        Page<GameCardDto> gamePage = gameCatalogService.getGameCatalog(pageable);
+
+        return ResponseEntity.ok(PagedResponseDto.from(gamePage));
+    }
+
+    /**
+     * Retrieves detailed information about a specific game.
+     *
+     * @param id the game ID
+     * @return game details
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<GameDetailDto> getGameById(@PathVariable UUID id) {
+        log.info("GET /api/games/{}", id);
+
+        GameDetailDto game = gameCatalogService.getGameDetails(id);
+        return ResponseEntity.ok(game);
+    }
+
+    /**
+     * Creates a Pageable from the sort string.
+     * Supports format: "field,direction" (e.g., "releaseDate,desc")
+     */
+    private Pageable createPageable(int page, int size, String sort) {
+        String[] sortParts = sort.split(",");
+        String sortField = sortParts[0].trim();
+        Sort.Direction direction = sortParts.length > 1
+                && sortParts[1].trim().equalsIgnoreCase("asc")
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+
+        // Map common sort fields to entity fields
+        String mappedField = mapSortField(sortField);
+
+        return PageRequest.of(page, size, Sort.by(direction, mappedField));
+    }
+
+    /**
+     * Maps API sort field names to entity field names.
+     */
+    private String mapSortField(String field) {
+        return switch (field.toLowerCase()) {
+            case "releasedate", "release_date" -> "releaseDate";
+            case "title", "name" -> "title";
+            case "rating" -> "averageRating"; // Note: requires special handling in query
+            case "createdat", "created_at" -> "createdAt";
+            default -> "releaseDate";
+        };
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/controllers/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/checkpoint/api/controllers/GlobalExceptionHandler.java
@@ -1,0 +1,92 @@
+package com.checkpoint.api.controllers;
+
+import java.time.LocalDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.checkpoint.api.services.GameNotFoundException;
+
+/**
+ * Global exception handler for REST controllers.
+ * Provides consistent error responses across all endpoints.
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    /**
+     * Handles GameNotFoundException.
+     *
+     * @param ex the exception
+     * @return error response with 404 status
+     */
+    @ExceptionHandler(GameNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleGameNotFound(GameNotFoundException ex) {
+        log.warn("Game not found: {}", ex.getMessage());
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                "Not Found",
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    /**
+     * Handles IllegalArgumentException for bad requests.
+     *
+     * @param ex the exception
+     * @return error response with 400 status
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+        log.warn("Bad request: {}", ex.getMessage());
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    /**
+     * Handles all other exceptions.
+     *
+     * @param ex the exception
+     * @return error response with 500 status
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
+        log.error("Unexpected error: {}", ex.getMessage(), ex);
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Internal Server Error",
+                "An unexpected error occurred",
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    /**
+     * Standard error response format.
+     */
+    public record ErrorResponse(
+            int status,
+            String error,
+            String message,
+            LocalDateTime timestamp
+    ) {}
+}

--- a/api/src/main/java/com/checkpoint/api/dto/catalog/GameCardDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/catalog/GameCardDto.java
@@ -1,0 +1,30 @@
+package com.checkpoint.api.dto.catalog;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * DTO for game cards displayed in the catalog list.
+ * Contains minimal information for displaying games in a grid/list view.
+ */
+public record GameCardDto(
+        UUID id,
+        String title,
+        String coverUrl,
+        LocalDate releaseDate,
+        Double averageRating,
+        Long ratingCount
+) {
+    /**
+     * Constructor for JPA projection.
+     */
+    public GameCardDto(UUID id, String title, String coverUrl, LocalDate releaseDate,
+                       Double averageRating, Long ratingCount) {
+        this.id = id;
+        this.title = title;
+        this.coverUrl = coverUrl;
+        this.releaseDate = releaseDate;
+        this.averageRating = averageRating != null ? Math.round(averageRating * 10.0) / 10.0 : null;
+        this.ratingCount = ratingCount != null ? ratingCount : 0L;
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/dto/catalog/GameDetailDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/catalog/GameDetailDto.java
@@ -1,0 +1,37 @@
+package com.checkpoint.api.dto.catalog;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * DTO for detailed game information.
+ * Contains all information needed for a game detail page.
+ */
+public record GameDetailDto(
+        UUID id,
+        String title,
+        String description,
+        String coverUrl,
+        LocalDate releaseDate,
+        Double averageRating,
+        Long ratingCount,
+        List<GenreDto> genres,
+        List<PlatformDto> platforms,
+        List<CompanyDto> companies
+) {
+    /**
+     * Nested DTO for genre information.
+     */
+    public record GenreDto(UUID id, String name) {}
+
+    /**
+     * Nested DTO for platform information.
+     */
+    public record PlatformDto(UUID id, String name) {}
+
+    /**
+     * Nested DTO for company information.
+     */
+    public record CompanyDto(UUID id, String name) {}
+}

--- a/api/src/main/java/com/checkpoint/api/dto/catalog/PagedResponseDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/catalog/PagedResponseDto.java
@@ -1,0 +1,51 @@
+package com.checkpoint.api.dto.catalog;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+/**
+ * Generic DTO for paginated responses.
+ * Wraps Spring's Page with a cleaner API for frontend consumption.
+ *
+ * @param <T> the type of content in the page
+ */
+public record PagedResponseDto<T>(
+        List<T> content,
+        PageMetadata metadata
+) {
+    /**
+     * Metadata about the page.
+     */
+    public record PageMetadata(
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean first,
+            boolean last,
+            boolean hasNext,
+            boolean hasPrevious
+    ) {}
+
+    /**
+     * Creates a PagedResponseDto from a Spring Page.
+     *
+     * @param page the Spring Page
+     * @param <T> the type of content
+     * @return a PagedResponseDto
+     */
+    public static <T> PagedResponseDto<T> from(Page<T> page) {
+        PageMetadata metadata = new PageMetadata(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast(),
+                page.hasNext(),
+                page.hasPrevious()
+        );
+        return new PagedResponseDto<>(page.getContent(), metadata);
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/repositories/VideoGameRepository.java
+++ b/api/src/main/java/com/checkpoint/api/repositories/VideoGameRepository.java
@@ -3,9 +3,14 @@ package com.checkpoint.api.repositories;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.checkpoint.api.dto.catalog.GameCardDto;
 import com.checkpoint.api.entities.VideoGame;
 
 /**
@@ -30,4 +35,60 @@ public interface VideoGameRepository extends JpaRepository<VideoGame, UUID> {
      * @return true if exists, false otherwise
      */
     boolean existsByIgdbId(Long igdbId);
+
+    /**
+     * Fetches a paginated list of games as GameCardDto projections.
+     * Uses a single query with aggregated rating calculation to avoid N+1 issues.
+     *
+     * @param pageable pagination and sorting parameters
+     * @return page of GameCardDto
+     */
+    @Query("""
+            SELECT new com.checkpoint.api.dto.catalog.GameCardDto(
+                vg.id,
+                vg.title,
+                vg.coverUrl,
+                vg.releaseDate,
+                AVG(CAST(r.score AS double)),
+                COUNT(r.id)
+            )
+            FROM VideoGame vg
+            LEFT JOIN vg.rates r
+            GROUP BY vg.id, vg.title, vg.coverUrl, vg.releaseDate
+            """)
+    Page<GameCardDto> findAllAsGameCards(Pageable pageable);
+
+    /**
+     * Fetches a video game with all its relationships eagerly loaded.
+     * Uses JOIN FETCH to avoid N+1 issues when accessing genres, platforms, and companies.
+     *
+     * @param id the video game ID
+     * @return Optional containing the video game with relationships loaded
+     */
+    @Query("""
+            SELECT vg FROM VideoGame vg
+            LEFT JOIN FETCH vg.genres
+            LEFT JOIN FETCH vg.platforms
+            LEFT JOIN FETCH vg.companies
+            WHERE vg.id = :id
+            """)
+    Optional<VideoGame> findByIdWithRelationships(@Param("id") UUID id);
+
+    /**
+     * Calculates the average rating for a video game.
+     *
+     * @param videoGameId the video game ID
+     * @return average rating or null if no ratings
+     */
+    @Query("SELECT AVG(CAST(r.score AS double)) FROM Rate r WHERE r.videoGame.id = :videoGameId")
+    Double calculateAverageRating(@Param("videoGameId") UUID videoGameId);
+
+    /**
+     * Counts the number of ratings for a video game.
+     *
+     * @param videoGameId the video game ID
+     * @return count of ratings
+     */
+    @Query("SELECT COUNT(r) FROM Rate r WHERE r.videoGame.id = :videoGameId")
+    Long countRatings(@Param("videoGameId") UUID videoGameId);
 }

--- a/api/src/main/java/com/checkpoint/api/services/GameCatalogService.java
+++ b/api/src/main/java/com/checkpoint/api/services/GameCatalogService.java
@@ -1,0 +1,33 @@
+package com.checkpoint.api.services;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.checkpoint.api.dto.catalog.GameCardDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto;
+
+/**
+ * Service interface for game catalog operations.
+ * Provides methods for retrieving games for public display.
+ */
+public interface GameCatalogService {
+
+    /**
+     * Retrieves a paginated list of games for the catalog.
+     *
+     * @param pageable pagination and sorting parameters
+     * @return page of game cards
+     */
+    Page<GameCardDto> getGameCatalog(Pageable pageable);
+
+    /**
+     * Retrieves detailed information about a specific game.
+     *
+     * @param id the game ID
+     * @return game details
+     * @throws GameNotFoundException if the game is not found
+     */
+    GameDetailDto getGameDetails(UUID id);
+}

--- a/api/src/main/java/com/checkpoint/api/services/GameCatalogServiceImpl.java
+++ b/api/src/main/java/com/checkpoint/api/services/GameCatalogServiceImpl.java
@@ -1,0 +1,93 @@
+package com.checkpoint.api.services;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.checkpoint.api.dto.catalog.GameCardDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto.CompanyDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto.GenreDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto.PlatformDto;
+import com.checkpoint.api.entities.VideoGame;
+import com.checkpoint.api.repositories.VideoGameRepository;
+
+/**
+ * Implementation of {@link GameCatalogService}.
+ * Provides optimized queries for game catalog operations.
+ */
+@Service
+@Transactional(readOnly = true)
+public class GameCatalogServiceImpl implements GameCatalogService {
+
+    private static final Logger log = LoggerFactory.getLogger(GameCatalogServiceImpl.class);
+
+    private final VideoGameRepository videoGameRepository;
+
+    public GameCatalogServiceImpl(VideoGameRepository videoGameRepository) {
+        this.videoGameRepository = videoGameRepository;
+    }
+
+    @Override
+    public Page<GameCardDto> getGameCatalog(Pageable pageable) {
+        log.debug("Fetching game catalog - page: {}, size: {}, sort: {}",
+                pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
+
+        return videoGameRepository.findAllAsGameCards(pageable);
+    }
+
+    @Override
+    public GameDetailDto getGameDetails(UUID id) {
+        log.debug("Fetching game details for ID: {}", id);
+
+        VideoGame game = videoGameRepository.findByIdWithRelationships(id)
+                .orElseThrow(() -> new GameNotFoundException(id));
+
+        // Get rating statistics
+        Double averageRating = videoGameRepository.calculateAverageRating(id);
+        Long ratingCount = videoGameRepository.countRatings(id);
+
+        return mapToGameDetailDto(game, averageRating, ratingCount);
+    }
+
+    /**
+     * Maps a VideoGame entity to a GameDetailDto.
+     */
+    private GameDetailDto mapToGameDetailDto(VideoGame game, Double averageRating, Long ratingCount) {
+        List<GenreDto> genres = game.getGenres().stream()
+                .map(g -> new GenreDto(g.getId(), g.getName()))
+                .toList();
+
+        List<PlatformDto> platforms = game.getPlatforms().stream()
+                .map(p -> new PlatformDto(p.getId(), p.getName()))
+                .toList();
+
+        List<CompanyDto> companies = game.getCompanies().stream()
+                .map(c -> new CompanyDto(c.getId(), c.getName()))
+                .toList();
+
+        // Round average rating to 1 decimal place
+        Double roundedRating = averageRating != null
+                ? Math.round(averageRating * 10.0) / 10.0
+                : null;
+
+        return new GameDetailDto(
+                game.getId(),
+                game.getTitle(),
+                game.getDescription(),
+                game.getCoverUrl(),
+                game.getReleaseDate(),
+                roundedRating,
+                ratingCount != null ? ratingCount : 0L,
+                genres,
+                platforms,
+                companies
+        );
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/services/GameNotFoundException.java
+++ b/api/src/main/java/com/checkpoint/api/services/GameNotFoundException.java
@@ -1,0 +1,20 @@
+package com.checkpoint.api.services;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a game is not found.
+ */
+public class GameNotFoundException extends RuntimeException {
+
+    private final UUID gameId;
+
+    public GameNotFoundException(UUID gameId) {
+        super("Game not found with ID: " + gameId);
+        this.gameId = gameId;
+    }
+
+    public UUID getGameId() {
+        return gameId;
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/controllers/GameControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/GameControllerTest.java
@@ -1,0 +1,141 @@
+package com.checkpoint.api.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.checkpoint.api.dto.catalog.GameCardDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto.CompanyDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto.GenreDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto.PlatformDto;
+import com.checkpoint.api.services.GameCatalogService;
+import com.checkpoint.api.services.GameNotFoundException;
+
+/**
+ * Unit tests for {@link GameController}.
+ */
+@WebMvcTest(GameController.class)
+class GameControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GameCatalogService gameCatalogService;
+
+    @Test
+    @DisplayName("GET /api/games should return paginated games")
+    void getGames_shouldReturnPaginatedGames() throws Exception {
+        // Given
+        UUID gameId = UUID.randomUUID();
+        List<GameCardDto> cards = List.of(
+                new GameCardDto(gameId, "The Witcher 3", "cover.jpg", LocalDate.of(2015, 5, 19), 4.8, 1500L)
+        );
+        Page<GameCardDto> page = new PageImpl<>(cards);
+
+        when(gameCatalogService.getGameCatalog(any(Pageable.class))).thenReturn(page);
+
+        // When / Then
+        mockMvc.perform(get("/api/games"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].title").value("The Witcher 3"))
+                .andExpect(jsonPath("$.content[0].coverUrl").value("cover.jpg"))
+                .andExpect(jsonPath("$.content[0].averageRating").value(4.8))
+                .andExpect(jsonPath("$.metadata.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /api/games should accept pagination parameters")
+    void getGames_shouldAcceptPaginationParameters() throws Exception {
+        // Given
+        Page<GameCardDto> emptyPage = new PageImpl<>(List.of());
+        when(gameCatalogService.getGameCatalog(any(Pageable.class))).thenReturn(emptyPage);
+
+        // When / Then
+        mockMvc.perform(get("/api/games")
+                        .param("page", "2")
+                        .param("size", "50")
+                        .param("sort", "title,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray());
+    }
+
+    @Test
+    @DisplayName("GET /api/games/{id} should return game details")
+    void getGameById_shouldReturnGameDetails() throws Exception {
+        // Given
+        UUID gameId = UUID.randomUUID();
+        GameDetailDto detail = new GameDetailDto(
+                gameId,
+                "The Witcher 3",
+                "An epic RPG",
+                "cover.jpg",
+                LocalDate.of(2015, 5, 19),
+                4.8,
+                1500L,
+                List.of(new GenreDto(UUID.randomUUID(), "RPG")),
+                List.of(new PlatformDto(UUID.randomUUID(), "PC")),
+                List.of(new CompanyDto(UUID.randomUUID(), "CD Projekt RED"))
+        );
+
+        when(gameCatalogService.getGameDetails(gameId)).thenReturn(detail);
+
+        // When / Then
+        mockMvc.perform(get("/api/games/{id}", gameId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(gameId.toString()))
+                .andExpect(jsonPath("$.title").value("The Witcher 3"))
+                .andExpect(jsonPath("$.description").value("An epic RPG"))
+                .andExpect(jsonPath("$.averageRating").value(4.8))
+                .andExpect(jsonPath("$.genres").isArray())
+                .andExpect(jsonPath("$.genres[0].name").value("RPG"))
+                .andExpect(jsonPath("$.platforms[0].name").value("PC"))
+                .andExpect(jsonPath("$.companies[0].name").value("CD Projekt RED"));
+    }
+
+    @Test
+    @DisplayName("GET /api/games/{id} should return 404 when game not found")
+    void getGameById_shouldReturn404WhenNotFound() throws Exception {
+        // Given
+        UUID gameId = UUID.randomUUID();
+        when(gameCatalogService.getGameDetails(gameId)).thenThrow(new GameNotFoundException(gameId));
+
+        // When / Then
+        mockMvc.perform(get("/api/games/{id}", gameId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Not Found"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    @DisplayName("GET /api/games should limit page size to max 100")
+    void getGames_shouldLimitPageSizeToMax() throws Exception {
+        // Given
+        Page<GameCardDto> emptyPage = new PageImpl<>(List.of());
+        when(gameCatalogService.getGameCatalog(any(Pageable.class))).thenReturn(emptyPage);
+
+        // When / Then - requesting size 500 should be capped
+        mockMvc.perform(get("/api/games")
+                        .param("size", "500"))
+                .andExpect(status().isOk());
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/services/GameCatalogServiceImplTest.java
+++ b/api/src/test/java/com/checkpoint/api/services/GameCatalogServiceImplTest.java
@@ -1,0 +1,155 @@
+package com.checkpoint.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.checkpoint.api.dto.catalog.GameCardDto;
+import com.checkpoint.api.dto.catalog.GameDetailDto;
+import com.checkpoint.api.entities.Company;
+import com.checkpoint.api.entities.Genre;
+import com.checkpoint.api.entities.Platform;
+import com.checkpoint.api.entities.VideoGame;
+import com.checkpoint.api.repositories.VideoGameRepository;
+
+/**
+ * Unit tests for {@link GameCatalogServiceImpl}.
+ */
+@ExtendWith(MockitoExtension.class)
+class GameCatalogServiceImplTest {
+
+    @Mock
+    private VideoGameRepository videoGameRepository;
+
+    private GameCatalogServiceImpl gameCatalogService;
+
+    @BeforeEach
+    void setUp() {
+        gameCatalogService = new GameCatalogServiceImpl(videoGameRepository);
+    }
+
+    @Test
+    @DisplayName("getGameCatalog should return paginated game cards")
+    void getGameCatalog_shouldReturnPaginatedGameCards() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "releaseDate"));
+
+        List<GameCardDto> cards = List.of(
+                new GameCardDto(UUID.randomUUID(), "Game 1", "cover1.jpg", LocalDate.of(2025, 1, 15), 4.5, 100L),
+                new GameCardDto(UUID.randomUUID(), "Game 2", "cover2.jpg", LocalDate.of(2025, 1, 10), 4.0, 50L)
+        );
+        Page<GameCardDto> expectedPage = new PageImpl<>(cards, pageable, 2);
+
+        when(videoGameRepository.findAllAsGameCards(pageable)).thenReturn(expectedPage);
+
+        // When
+        Page<GameCardDto> result = gameCatalogService.getGameCatalog(pageable);
+
+        // Then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).title()).isEqualTo("Game 1");
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        verify(videoGameRepository).findAllAsGameCards(pageable);
+    }
+
+    @Test
+    @DisplayName("getGameDetails should return full game details")
+    void getGameDetails_shouldReturnFullGameDetails() {
+        // Given
+        UUID gameId = UUID.randomUUID();
+
+        VideoGame game = new VideoGame();
+        game.setId(gameId);
+        game.setTitle("The Witcher 3");
+        game.setDescription("An epic RPG adventure");
+        game.setCoverUrl("witcher3-cover.jpg");
+        game.setReleaseDate(LocalDate.of(2015, 5, 19));
+
+        Genre genre = new Genre("RPG");
+        genre.setId(UUID.randomUUID());
+        game.setGenres(Set.of(genre));
+
+        Platform platform = new Platform("PC");
+        platform.setId(UUID.randomUUID());
+        game.setPlatforms(Set.of(platform));
+
+        Company company = new Company("CD Projekt RED");
+        company.setId(UUID.randomUUID());
+        game.setCompanies(Set.of(company));
+
+        when(videoGameRepository.findByIdWithRelationships(gameId)).thenReturn(Optional.of(game));
+        when(videoGameRepository.calculateAverageRating(gameId)).thenReturn(4.8);
+        when(videoGameRepository.countRatings(gameId)).thenReturn(1500L);
+
+        // When
+        GameDetailDto result = gameCatalogService.getGameDetails(gameId);
+
+        // Then
+        assertThat(result.id()).isEqualTo(gameId);
+        assertThat(result.title()).isEqualTo("The Witcher 3");
+        assertThat(result.description()).isEqualTo("An epic RPG adventure");
+        assertThat(result.averageRating()).isEqualTo(4.8);
+        assertThat(result.ratingCount()).isEqualTo(1500L);
+        assertThat(result.genres()).hasSize(1);
+        assertThat(result.genres().get(0).name()).isEqualTo("RPG");
+        assertThat(result.platforms()).hasSize(1);
+        assertThat(result.companies()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getGameDetails should throw GameNotFoundException when game not found")
+    void getGameDetails_shouldThrowWhenGameNotFound() {
+        // Given
+        UUID gameId = UUID.randomUUID();
+        when(videoGameRepository.findByIdWithRelationships(gameId)).thenReturn(Optional.empty());
+
+        // When / Then
+        assertThatThrownBy(() -> gameCatalogService.getGameDetails(gameId))
+                .isInstanceOf(GameNotFoundException.class)
+                .hasMessageContaining(gameId.toString());
+    }
+
+    @Test
+    @DisplayName("getGameDetails should handle null rating gracefully")
+    void getGameDetails_shouldHandleNullRating() {
+        // Given
+        UUID gameId = UUID.randomUUID();
+
+        VideoGame game = new VideoGame();
+        game.setId(gameId);
+        game.setTitle("New Game");
+        game.setGenres(Set.of());
+        game.setPlatforms(Set.of());
+        game.setCompanies(Set.of());
+
+        when(videoGameRepository.findByIdWithRelationships(gameId)).thenReturn(Optional.of(game));
+        when(videoGameRepository.calculateAverageRating(gameId)).thenReturn(null);
+        when(videoGameRepository.countRatings(gameId)).thenReturn(0L);
+
+        // When
+        GameDetailDto result = gameCatalogService.getGameDetails(gameId);
+
+        // Then
+        assertThat(result.averageRating()).isNull();
+        assertThat(result.ratingCount()).isEqualTo(0L);
+    }
+}


### PR DESCRIPTION
…E-139]

- Add GameCardDto, GameDetailDto, PagedResponseDto for API responses
- Create GameCatalogService with optimized JPA queries
- Add GET /api/games with page, size, sort parameters
- Add GET /api/games/{id} for detailed game information
- Implement GlobalExceptionHandler for consistent error responses
- Use JPA projections and JOIN FETCH to avoid N+1 issues
- Add unit tests for controller and service layers