### PR TITLE
feat(api): decouple rating from review with standalone rating endpoints (TE-168)

### DIFF
--- a/api/bruno/rate/Get My Rating.bru
+++ b/api/bruno/rate/Get My Rating.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Get My Rating
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/me/games/:videoGameId/rate
+  body: none
+  auth: bearer
+}
+
+params:path {
+  videoGameId: ad3b5b63-bf94-4945-b0bf-f1c62d8c3107
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  # Get My Rating
+
+  Retrieves the authenticated user's rating for a specific video game.
+
+  ## Authentication
+
+  Requires a valid JWT token in the `Authorization: Bearer` header.
+
+  ## Path Parameters
+
+  - **videoGameId**: The UUID of the video game
+
+  ## Response (200 OK)
+
+  ```json
+  {
+    "id": "uuid",
+    "score": 5,
+    "videoGameId": "uuid",
+    "createdAt": "2025-06-01T10:00:00",
+    "updatedAt": "2025-06-01T10:00:00"
+  }
+  ```
+
+  ## Error Responses
+
+  - **401 Unauthorized**: Not authenticated
+  - **404 Not Found**: No rating found for this game
+}

--- a/api/bruno/rate/Rate Game.bru
+++ b/api/bruno/rate/Rate Game.bru
@@ -1,0 +1,64 @@
+meta {
+  name: Rate Game
+  type: http
+  seq: 1
+}
+
+put {
+  url: {{baseUrl}}/api/me/games/:videoGameId/rate
+  body: json
+  auth: bearer
+}
+
+params:path {
+  videoGameId: ad3b5b63-bf94-4945-b0bf-f1c62d8c3107
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "score": 5
+  }
+}
+
+docs {
+  # Rate Game
+
+  Creates or updates the authenticated user's rating for a specific video game.
+  If the user has already rated this game, the existing rating is updated.
+
+  ## Authentication
+
+  Requires a valid JWT token in the `Authorization: Bearer` header.
+
+  ## Path Parameters
+
+  - **videoGameId**: The UUID of the video game to rate
+
+  ## Request Body
+
+  | Field | Type | Required | Description |
+  |-------|------|----------|-------------|
+  | score | Integer | Yes | Rating score from 1 to 5 |
+
+  ## Response (200 OK)
+
+  ```json
+  {
+    "id": "uuid",
+    "score": 5,
+    "videoGameId": "uuid",
+    "createdAt": "2025-06-01T10:00:00",
+    "updatedAt": "2025-06-01T10:00:00"
+  }
+  ```
+
+  ## Error Responses
+
+  - **400 Bad Request**: Missing or invalid score (must be between 1 and 5)
+  - **401 Unauthorized**: Not authenticated
+  - **404 Not Found**: Video game does not exist
+}

--- a/api/bruno/rate/Remove Rating.bru
+++ b/api/bruno/rate/Remove Rating.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Remove Rating
+  type: http
+  seq: 3
+}
+
+delete {
+  url: {{baseUrl}}/api/me/games/:videoGameId/rate
+  body: none
+  auth: bearer
+}
+
+params:path {
+  videoGameId: ad3b5b63-bf94-4945-b0bf-f1c62d8c3107
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  # Remove Rating
+
+  Removes the authenticated user's rating for a specific video game.
+
+  ## Authentication
+
+  Requires a valid JWT token in the `Authorization: Bearer` header.
+
+  ## Path Parameters
+
+  - **videoGameId**: The UUID of the video game
+
+  ## Response (204 No Content)
+
+  Empty response body on success.
+
+  ## Error Responses
+
+  - **401 Unauthorized**: Not authenticated
+  - **404 Not Found**: No rating found for this game
+}

--- a/api/bruno/rate/folder.bru
+++ b/api/bruno/rate/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: rate
+}

--- a/api/bruno/reviews/Submit or Update Review.bru
+++ b/api/bruno/reviews/Submit or Update Review.bru
@@ -20,7 +20,6 @@ auth:bearer {
 
 body:json {
   {
-    "score": 5,
     "content": "This game is absolutely amazing!",
     "haveSpoilers": false
   }

--- a/api/src/main/java/com/checkpoint/api/controllers/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/checkpoint/api/controllers/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.checkpoint.api.exceptions.ExternalApiUnavailableException;
+import com.checkpoint.api.exceptions.IgdbApiException;
 import com.checkpoint.api.exceptions.ExternalGameNotFoundException;
 import com.checkpoint.api.exceptions.GameAlreadyInLibraryException;
 import com.checkpoint.api.exceptions.GameNotFoundException;
@@ -26,6 +27,7 @@ import com.checkpoint.api.exceptions.GameNotInWishlistException;
 import com.checkpoint.api.exceptions.InvalidTokenException;
 import com.checkpoint.api.exceptions.RegistrationConflictException;
 import com.checkpoint.api.exceptions.PlayLogNotFoundException;
+import com.checkpoint.api.exceptions.RateNotFoundException;
 
 /**
  * Global exception handler for REST controllers.
@@ -85,6 +87,27 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ExternalApiUnavailableException.class)
     public ResponseEntity<ErrorResponse> handleExternalApiUnavailable(ExternalApiUnavailableException ex) {
         log.error("External API unavailable: {}", ex.getMessage());
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.SERVICE_UNAVAILABLE.value(),
+                "Service Unavailable",
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(error);
+    }
+
+    /**
+     * Handles IgdbApiException as a safety net when the exception is not caught
+     * and re-wrapped by a service layer.
+     *
+     * @param ex the exception
+     * @return error response with 503 status
+     */
+    @ExceptionHandler(IgdbApiException.class)
+    public ResponseEntity<ErrorResponse> handleIgdbApiException(IgdbApiException ex) {
+        log.error("IGDB API error: {}", ex.getMessage());
 
         ErrorResponse error = new ErrorResponse(
                 HttpStatus.SERVICE_UNAVAILABLE.value(),
@@ -235,6 +258,26 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
     }
+    /**
+     * Handles RateNotFoundException when a rating is not found for a user and game.
+     *
+     * @param ex the exception
+     * @return error response with 404 status
+     */
+    @ExceptionHandler(RateNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleRateNotFound(RateNotFoundException ex) {
+        log.warn("Rating not found: {}", ex.getMessage());
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                "Not Found",
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
     /**
      * Handles missing required request parameters.
      *

--- a/api/src/main/java/com/checkpoint/api/controllers/RateController.java
+++ b/api/src/main/java/com/checkpoint/api/controllers/RateController.java
@@ -1,0 +1,102 @@
+package com.checkpoint.api.controllers;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.checkpoint.api.dto.catalog.RateRequestDto;
+import com.checkpoint.api.dto.catalog.RateResponseDto;
+import com.checkpoint.api.services.RateService;
+
+import jakarta.validation.Valid;
+
+/**
+ * REST controller for standalone game rating endpoints.
+ *
+ * <p>All endpoints require authentication (JWT or session).
+ * The authenticated user is resolved from the security context.</p>
+ */
+@RestController
+@RequestMapping("/api/me/games/{videoGameId}/rate")
+public class RateController {
+
+    private static final Logger log = LoggerFactory.getLogger(RateController.class);
+
+    private final RateService rateService;
+
+    public RateController(RateService rateService) {
+        this.rateService = rateService;
+    }
+
+    /**
+     * Creates or updates the authenticated user's rating for a specific game.
+     *
+     * @param userDetails the authenticated user principal
+     * @param videoGameId the video game ID
+     * @param request the rate request body containing the score
+     * @return the created or updated rating
+     */
+    @PutMapping
+    public ResponseEntity<RateResponseDto> rateGame(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID videoGameId,
+            @Valid @RequestBody RateRequestDto request) {
+
+        log.info("PUT /api/me/games/{}/rate - user: {}, score: {}", videoGameId, userDetails.getUsername(), request.score());
+
+        RateResponseDto response = rateService.rateGame(userDetails.getUsername(), videoGameId, request.score());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Removes the authenticated user's rating for a specific game.
+     *
+     * @param userDetails the authenticated user principal
+     * @param videoGameId the video game ID
+     * @return 204 No Content
+     */
+    @DeleteMapping
+    public ResponseEntity<Void> removeRating(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID videoGameId) {
+
+        log.info("DELETE /api/me/games/{}/rate - user: {}", videoGameId, userDetails.getUsername());
+
+        rateService.removeRating(userDetails.getUsername(), videoGameId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Retrieves the authenticated user's rating for a specific game.
+     *
+     * @param userDetails the authenticated user principal
+     * @param videoGameId the video game ID
+     * @return the rating if found, or 404 Not Found if no rating exists
+     */
+    @GetMapping
+    public ResponseEntity<RateResponseDto> getMyRating(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID videoGameId) {
+
+        log.info("GET /api/me/games/{}/rate - user: {}", videoGameId, userDetails.getUsername());
+
+        RateResponseDto response = rateService.getUserRating(userDetails.getUsername(), videoGameId);
+
+        if (response == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/controllers/ReviewController.java
+++ b/api/src/main/java/com/checkpoint/api/controllers/ReviewController.java
@@ -82,7 +82,7 @@ public class ReviewController {
      *
      * @param userDetails the authenticated user principal
      * @param gameId the video game ID
-     * @param request the review request body containing score and content
+     * @param request the review request body containing content and spoiler flag
      * @return the created or updated review
      */
     @PostMapping
@@ -91,9 +91,7 @@ public class ReviewController {
             @PathVariable UUID gameId,
             @Valid @RequestBody ReviewRequestDto request) {
 
-        log.info("POST /api/games/{}/reviews - user: {}, score: {}", gameId, userDetails.getUsername(), request.score());
-
-        // Because UserDetails username is mapped to the email. Wait, in UserGameCollection it passes username.
+        log.info("POST /api/games/{}/reviews - user: {}", gameId, userDetails.getUsername());
         ReviewResponseDto response = reviewService.addOrUpdateReview(userDetails.getUsername(), gameId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -162,7 +160,6 @@ public class ReviewController {
         return switch (field.toLowerCase()) {
             case "createdat", "created_at" -> "createdAt";
             case "updatedat", "updated_at" -> "updatedAt";
-            case "score", "rating" -> "score";
             default -> "createdAt";
         };
     }

--- a/api/src/main/java/com/checkpoint/api/dto/catalog/RateRequestDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/catalog/RateRequestDto.java
@@ -1,0 +1,16 @@
+package com.checkpoint.api.dto.catalog;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * DTO for creating or updating a standalone rating.
+ */
+public record RateRequestDto(
+    @NotNull(message = "Score is required")
+    @Min(value = 1, message = "Score must be at least 1")
+    @Max(value = 5, message = "Score must be at most 5")
+    Integer score
+) {
+}

--- a/api/src/main/java/com/checkpoint/api/dto/catalog/RateResponseDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/catalog/RateResponseDto.java
@@ -1,0 +1,16 @@
+package com.checkpoint.api.dto.catalog;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * DTO representing a rating returned to the client.
+ */
+public record RateResponseDto(
+    UUID id,
+    Integer score,
+    UUID videoGameId,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+}

--- a/api/src/main/java/com/checkpoint/api/dto/catalog/ReviewRequestDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/catalog/ReviewRequestDto.java
@@ -1,18 +1,9 @@
 package com.checkpoint.api.dto.catalog;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-
 /**
  * DTO for creating or updating a review.
  */
 public record ReviewRequestDto(
-    @NotNull(message = "Score is required")
-    @Min(value = 1, message = "Score must be at least 1")
-    @Max(value = 5, message = "Score must be at most 5")
-    Integer score,
-
     String content,
 
     Boolean haveSpoilers

--- a/api/src/main/java/com/checkpoint/api/dto/catalog/ReviewResponseDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/catalog/ReviewResponseDto.java
@@ -8,7 +8,6 @@ import java.util.UUID;
  */
 public record ReviewResponseDto(
     UUID id,
-    Integer score,
     String content,
     Boolean haveSpoilers,
     LocalDateTime createdAt,

--- a/api/src/main/java/com/checkpoint/api/exceptions/RateNotFoundException.java
+++ b/api/src/main/java/com/checkpoint/api/exceptions/RateNotFoundException.java
@@ -1,0 +1,13 @@
+package com.checkpoint.api.exceptions;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a rating is not found for a specific user and game.
+ */
+public class RateNotFoundException extends RuntimeException {
+
+    public RateNotFoundException(UUID videoGameId) {
+        super("Rating not found for game with ID: " + videoGameId);
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/mapper/RateMapper.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/RateMapper.java
@@ -1,0 +1,18 @@
+package com.checkpoint.api.mapper;
+
+import com.checkpoint.api.dto.catalog.RateResponseDto;
+import com.checkpoint.api.entities.Rate;
+
+/**
+ * Mapper for converting Rate entities to DTOs.
+ */
+public interface RateMapper {
+
+    /**
+     * Maps a Rate entity to a RateResponseDto.
+     *
+     * @param rate the rate entity
+     * @return the rate response DTO
+     */
+    RateResponseDto toDto(Rate rate);
+}

--- a/api/src/main/java/com/checkpoint/api/mapper/ReviewMapper.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/ReviewMapper.java
@@ -9,11 +9,10 @@ import com.checkpoint.api.entities.Review;
 public interface ReviewMapper {
 
     /**
-     * Maps a Review entity and its associated score to a ReviewResponseDto.
+     * Maps a Review entity to a ReviewResponseDto.
      *
      * @param review the review entity
-     * @param score the numeric score
      * @return the review response DTO
      */
-    ReviewResponseDto toDto(Review review, Integer score);
+    ReviewResponseDto toDto(Review review);
 }

--- a/api/src/main/java/com/checkpoint/api/mapper/impl/RateMapperImpl.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/impl/RateMapperImpl.java
@@ -1,0 +1,29 @@
+package com.checkpoint.api.mapper.impl;
+
+import org.springframework.stereotype.Component;
+
+import com.checkpoint.api.dto.catalog.RateResponseDto;
+import com.checkpoint.api.entities.Rate;
+import com.checkpoint.api.mapper.RateMapper;
+
+/**
+ * Implementation of {@link RateMapper}.
+ */
+@Component
+public class RateMapperImpl implements RateMapper {
+
+    @Override
+    public RateResponseDto toDto(Rate rate) {
+        if (rate == null) {
+            return null;
+        }
+
+        return new RateResponseDto(
+                rate.getId(),
+                rate.getScore(),
+                rate.getVideoGame().getId(),
+                rate.getCreatedAt(),
+                rate.getUpdatedAt()
+        );
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/mapper/impl/ReviewMapperImpl.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/impl/ReviewMapperImpl.java
@@ -8,11 +8,14 @@ import com.checkpoint.api.entities.Review;
 import com.checkpoint.api.entities.User;
 import com.checkpoint.api.mapper.ReviewMapper;
 
+/**
+ * Implementation of {@link ReviewMapper}.
+ */
 @Component
 public class ReviewMapperImpl implements ReviewMapper {
 
     @Override
-    public ReviewResponseDto toDto(Review review, Integer score) {
+    public ReviewResponseDto toDto(Review review) {
         if (review == null) {
             return null;
         }
@@ -29,7 +32,6 @@ public class ReviewMapperImpl implements ReviewMapper {
 
         return new ReviewResponseDto(
                 review.getId(),
-                score,
                 review.getContent(),
                 review.getHaveSpoilers(),
                 review.getCreatedAt(),

--- a/api/src/main/java/com/checkpoint/api/repositories/RateRepository.java
+++ b/api/src/main/java/com/checkpoint/api/repositories/RateRepository.java
@@ -16,6 +16,15 @@ import com.checkpoint.api.entities.Rate;
 public interface RateRepository extends JpaRepository<Rate, UUID> {
 
     /**
+     * Finds a user's rate for a specific video game by user email.
+     *
+     * @param email the user's email
+     * @param videoGameId the video game ID
+     * @return an optional containing the rate if found
+     */
+    Optional<Rate> findByUserEmailAndVideoGameId(String email, UUID videoGameId);
+
+    /**
      * Finds a user's rate for a specific video game.
      *
      * @param pseudo the user's pseudo

--- a/api/src/main/java/com/checkpoint/api/services/RateService.java
+++ b/api/src/main/java/com/checkpoint/api/services/RateService.java
@@ -1,0 +1,38 @@
+package com.checkpoint.api.services;
+
+import java.util.UUID;
+
+import com.checkpoint.api.dto.catalog.RateResponseDto;
+
+/**
+ * Service for managing standalone game ratings.
+ */
+public interface RateService {
+
+    /**
+     * Creates or updates the authenticated user's rating for a specific video game.
+     *
+     * @param userEmail the authenticated user's email
+     * @param videoGameId the video game ID
+     * @param score the rating score (1-5)
+     * @return the created or updated rating
+     */
+    RateResponseDto rateGame(String userEmail, UUID videoGameId, Integer score);
+
+    /**
+     * Removes the authenticated user's rating for a specific video game.
+     *
+     * @param userEmail the authenticated user's email
+     * @param videoGameId the video game ID
+     */
+    void removeRating(String userEmail, UUID videoGameId);
+
+    /**
+     * Retrieves the authenticated user's rating for a specific video game.
+     *
+     * @param userEmail the authenticated user's email
+     * @param videoGameId the video game ID
+     * @return the rating if found, null otherwise
+     */
+    RateResponseDto getUserRating(String userEmail, UUID videoGameId);
+}

--- a/api/src/main/java/com/checkpoint/api/services/impl/RateServiceImpl.java
+++ b/api/src/main/java/com/checkpoint/api/services/impl/RateServiceImpl.java
@@ -1,0 +1,115 @@
+package com.checkpoint.api.services.impl;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.checkpoint.api.dto.catalog.RateResponseDto;
+import com.checkpoint.api.entities.Rate;
+import com.checkpoint.api.entities.User;
+import com.checkpoint.api.entities.VideoGame;
+import com.checkpoint.api.exceptions.GameNotFoundException;
+import com.checkpoint.api.exceptions.RateNotFoundException;
+import com.checkpoint.api.mapper.RateMapper;
+import com.checkpoint.api.repositories.RateRepository;
+import com.checkpoint.api.repositories.UserRepository;
+import com.checkpoint.api.repositories.VideoGameRepository;
+import com.checkpoint.api.services.RateService;
+
+/**
+ * Implementation of {@link RateService}.
+ * Manages standalone game ratings independently from reviews.
+ */
+@Service
+@Transactional
+public class RateServiceImpl implements RateService {
+
+    private static final Logger log = LoggerFactory.getLogger(RateServiceImpl.class);
+
+    private final RateRepository rateRepository;
+    private final VideoGameRepository videoGameRepository;
+    private final UserRepository userRepository;
+    private final RateMapper rateMapper;
+
+    public RateServiceImpl(RateRepository rateRepository,
+                           VideoGameRepository videoGameRepository,
+                           UserRepository userRepository,
+                           RateMapper rateMapper) {
+        this.rateRepository = rateRepository;
+        this.videoGameRepository = videoGameRepository;
+        this.userRepository = userRepository;
+        this.rateMapper = rateMapper;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RateResponseDto rateGame(String userEmail, UUID videoGameId, Integer score) {
+        log.info("Rating game {} with score {} for user {}", videoGameId, score, userEmail);
+
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + userEmail));
+
+        VideoGame videoGame = videoGameRepository.findById(videoGameId)
+                .orElseThrow(() -> new GameNotFoundException(videoGameId));
+
+        Rate rate = rateRepository.findByUserEmailAndVideoGameId(userEmail, videoGameId)
+                .orElseGet(() -> new Rate(user, videoGame, score));
+        rate.setScore(score);
+        Rate savedRate = rateRepository.save(rate);
+
+        updateGameAverageRating(videoGame);
+
+        return rateMapper.toDto(savedRate);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeRating(String userEmail, UUID videoGameId) {
+        log.info("Removing rating for game {} for user {}", videoGameId, userEmail);
+
+        Rate rate = rateRepository.findByUserEmailAndVideoGameId(userEmail, videoGameId)
+                .orElseThrow(() -> new RateNotFoundException(videoGameId));
+
+        VideoGame videoGame = rate.getVideoGame();
+        rateRepository.delete(rate);
+
+        updateGameAverageRating(videoGame);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public RateResponseDto getUserRating(String userEmail, UUID videoGameId) {
+        log.debug("Fetching rating for game {} for user {}", videoGameId, userEmail);
+
+        Rate rate = rateRepository.findByUserEmailAndVideoGameId(userEmail, videoGameId)
+                .orElse(null);
+
+        return rateMapper.toDto(rate);
+    }
+
+    /**
+     * Recalculates and persists the average rating for a video game.
+     *
+     * @param videoGame the video game entity to update
+     */
+    private void updateGameAverageRating(VideoGame videoGame) {
+        rateRepository.flush();
+        Double avg = rateRepository.calculateAverageRating(videoGame.getId());
+        double averageRating = (avg != null) ? avg : 0.0;
+
+        averageRating = Math.round(averageRating * 10.0) / 10.0;
+
+        videoGame.setAverageRating(averageRating);
+        videoGameRepository.save(videoGame);
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/services/impl/ReviewServiceImpl.java
+++ b/api/src/main/java/com/checkpoint/api/services/impl/ReviewServiceImpl.java
@@ -9,35 +9,34 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.checkpoint.api.dto.catalog.ReviewRequestDto;
 import com.checkpoint.api.dto.catalog.ReviewResponseDto;
-import com.checkpoint.api.entities.Rate;
 import com.checkpoint.api.entities.Review;
 import com.checkpoint.api.entities.User;
 import com.checkpoint.api.entities.VideoGame;
 import com.checkpoint.api.exceptions.GameNotFoundException;
 import com.checkpoint.api.mapper.ReviewMapper;
-import com.checkpoint.api.repositories.RateRepository;
 import com.checkpoint.api.repositories.ReviewRepository;
 import com.checkpoint.api.repositories.UserRepository;
 import com.checkpoint.api.repositories.VideoGameRepository;
 import com.checkpoint.api.services.ReviewService;
 
+/**
+ * Implementation of {@link ReviewService}.
+ * Manages game reviews independently from ratings.
+ */
 @Service
 @Transactional
 public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewRepository reviewRepository;
-    private final RateRepository rateRepository;
     private final VideoGameRepository videoGameRepository;
     private final UserRepository userRepository;
     private final ReviewMapper reviewMapper;
 
     public ReviewServiceImpl(ReviewRepository reviewRepository,
-                             RateRepository rateRepository,
                              VideoGameRepository videoGameRepository,
                              UserRepository userRepository,
                              ReviewMapper reviewMapper) {
         this.reviewRepository = reviewRepository;
-        this.rateRepository = rateRepository;
         this.videoGameRepository = videoGameRepository;
         this.userRepository = userRepository;
         this.reviewMapper = reviewMapper;
@@ -51,22 +50,13 @@ public class ReviewServiceImpl implements ReviewService {
         VideoGame videoGame = videoGameRepository.findById(videoGameId)
                 .orElseThrow(() -> new GameNotFoundException(videoGameId));
 
-        // Handle Rate
-        Rate rate = rateRepository.findByUserPseudoAndVideoGameId(user.getPseudo(), videoGameId)
-                .orElseGet(() -> new Rate(user, videoGame, request.score()));
-        rate.setScore(request.score());
-        rateRepository.save(rate);
-
-        // Handle Review
         Review review = reviewRepository.findByUserPseudoAndVideoGameId(user.getPseudo(), videoGameId)
                 .orElseGet(() -> new Review(request.content(), request.haveSpoilers(), user, videoGame));
         review.setContent(request.content());
         review.setHaveSpoilers(request.haveSpoilers());
         Review savedReview = reviewRepository.save(review);
 
-        updateGameAverageRating(videoGame);
-
-        return reviewMapper.toDto(savedReview, rate.getScore());
+        return reviewMapper.toDto(savedReview);
     }
 
     @Override
@@ -78,20 +68,7 @@ public class ReviewServiceImpl implements ReviewService {
 
         Page<Review> reviews = reviewRepository.findByVideoGameId(videoGameId, pageable);
 
-        // Fetch all rates for the users in this page to populate the score
-        java.util.List<UUID> userIds = reviews.stream()
-                .map(r -> r.getUser().getId())
-                .toList();
-
-        java.util.Map<UUID, Integer> userScoreMap = new java.util.HashMap<>();
-        if (!userIds.isEmpty()) {
-            java.util.List<Rate> rates = rateRepository.findByVideoGameIdAndUserIdIn(videoGameId, userIds);
-            for (Rate r : rates) {
-                userScoreMap.put(r.getUser().getId(), r.getScore());
-            }
-        }
-
-        return reviews.map(review -> reviewMapper.toDto(review, userScoreMap.get(review.getUser().getId())));
+        return reviews.map(reviewMapper::toDto);
     }
 
     @Override
@@ -102,29 +79,7 @@ public class ReviewServiceImpl implements ReviewService {
         Review review = reviewRepository.findByUserPseudoAndVideoGameId(user.getPseudo(), videoGameId)
                 .orElseThrow(() -> new IllegalArgumentException("Review not found for this user and game"));
 
-        Rate rate = rateRepository.findByUserPseudoAndVideoGameId(user.getPseudo(), videoGameId)
-                .orElse(null);
-
         reviewRepository.delete(review);
-        if (rate != null) {
-            rateRepository.delete(rate);
-        }
-
-        VideoGame videoGame = review.getVideoGame();
-        updateGameAverageRating(videoGame);
-    }
-
-    private void updateGameAverageRating(VideoGame videoGame) {
-        // Needs a flush so the current uncommitted changes or deletions are visible to the average query
-        rateRepository.flush();
-        Double avg = rateRepository.calculateAverageRating(videoGame.getId());
-        double averageRating = (avg != null) ? avg : 0.0;
-
-        // Round to 1 decimal place if you want, or keep it as is.
-        averageRating = Math.round(averageRating * 10.0) / 10.0;
-
-        videoGame.setAverageRating(averageRating);
-        videoGameRepository.save(videoGame);
     }
 
     @Override
@@ -144,11 +99,6 @@ public class ReviewServiceImpl implements ReviewService {
             return null;
         }
 
-        Rate rate = rateRepository.findByUserPseudoAndVideoGameId(user.getPseudo(), videoGameId)
-                .orElse(null);
-
-        Integer score = (rate != null) ? rate.getScore() : null;
-
-        return reviewMapper.toDto(review, score);
+        return reviewMapper.toDto(review);
     }
 }

--- a/api/src/test/java/com/checkpoint/api/controllers/RateControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/RateControllerTest.java
@@ -1,0 +1,152 @@
+package com.checkpoint.api.controllers;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.checkpoint.api.dto.catalog.RateRequestDto;
+import com.checkpoint.api.dto.catalog.RateResponseDto;
+import com.checkpoint.api.security.ApiAuthenticationEntryPoint;
+import com.checkpoint.api.security.JwtAuthenticationFilter;
+import com.checkpoint.api.services.RateService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = RateController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class RateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private RateService rateService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private ApiAuthenticationEntryPoint apiAuthenticationEntryPoint;
+
+    private UUID videoGameId;
+    private RateResponseDto rateResponseDto;
+
+    @BeforeEach
+    void setUp() {
+        videoGameId = UUID.randomUUID();
+        rateResponseDto = new RateResponseDto(
+                UUID.randomUUID(),
+                4,
+                videoGameId,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    @DisplayName("PUT /api/me/games/{videoGameId}/rate should return 200 OK with the rating")
+    void rateGame_shouldReturnRating() throws Exception {
+        // Given
+        RateRequestDto request = new RateRequestDto(4);
+        when(rateService.rateGame(eq("testuser"), eq(videoGameId), eq(4)))
+                .thenReturn(rateResponseDto);
+
+        // When & Then
+        mockMvc.perform(put("/api/me/games/{videoGameId}/rate", videoGameId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.score").value(4))
+                .andExpect(jsonPath("$.videoGameId").value(videoGameId.toString()));
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    @DisplayName("PUT /api/me/games/{videoGameId}/rate should return 400 when score is missing")
+    void rateGame_shouldReturn400WhenScoreMissing() throws Exception {
+        // Given
+        String requestBody = "{}";
+
+        // When & Then
+        mockMvc.perform(put("/api/me/games/{videoGameId}/rate", videoGameId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    @DisplayName("PUT /api/me/games/{videoGameId}/rate should return 400 when score is out of range")
+    void rateGame_shouldReturn400WhenScoreOutOfRange() throws Exception {
+        // Given
+        RateRequestDto request = new RateRequestDto(6);
+
+        // When & Then
+        mockMvc.perform(put("/api/me/games/{videoGameId}/rate", videoGameId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    @DisplayName("DELETE /api/me/games/{videoGameId}/rate should return 204 No Content")
+    void removeRating_shouldReturn204() throws Exception {
+        // Given
+        doNothing().when(rateService).removeRating(eq("testuser"), eq(videoGameId));
+
+        // When & Then
+        mockMvc.perform(delete("/api/me/games/{videoGameId}/rate", videoGameId))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    @DisplayName("GET /api/me/games/{videoGameId}/rate should return 200 OK when rating exists")
+    void getMyRating_shouldReturnRating() throws Exception {
+        // Given
+        when(rateService.getUserRating(eq("testuser"), eq(videoGameId)))
+                .thenReturn(rateResponseDto);
+
+        // When & Then
+        mockMvc.perform(get("/api/me/games/{videoGameId}/rate", videoGameId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.score").value(4))
+                .andExpect(jsonPath("$.videoGameId").value(videoGameId.toString()));
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    @DisplayName("GET /api/me/games/{videoGameId}/rate should return 404 when no rating exists")
+    void getMyRating_shouldReturn404WhenNoRatingExists() throws Exception {
+        // Given
+        when(rateService.getUserRating(eq("testuser"), eq(videoGameId)))
+                .thenReturn(null);
+
+        // When & Then
+        mockMvc.perform(get("/api/me/games/{videoGameId}/rate", videoGameId))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/controllers/ReviewControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/ReviewControllerTest.java
@@ -24,7 +24,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.checkpoint.api.config.SecurityConfig;
 import com.checkpoint.api.dto.catalog.ReviewRequestDto;
 import com.checkpoint.api.dto.catalog.ReviewResponseDto;
 import com.checkpoint.api.security.ApiAuthenticationEntryPoint;
@@ -33,7 +32,7 @@ import com.checkpoint.api.services.ReviewService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = ReviewController.class)
-@AutoConfigureMockMvc(addFilters = false) // Disable security filters for unit testing controller logic
+@AutoConfigureMockMvc(addFilters = false)
 class ReviewControllerTest {
 
     @Autowired
@@ -57,7 +56,7 @@ class ReviewControllerTest {
     @BeforeEach
     void setUp() {
         gameId = UUID.randomUUID();
-        reviewResponseDto = new ReviewResponseDto(UUID.randomUUID(), 5, "Great game!", false, null, null, null);
+        reviewResponseDto = new ReviewResponseDto(UUID.randomUUID(), "Great game!", false, null, null, null);
     }
 
     @Test
@@ -70,7 +69,6 @@ class ReviewControllerTest {
         // When & Then
         mockMvc.perform(get("/api/games/{gameId}/reviews", gameId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].score").value(5))
                 .andExpect(jsonPath("$.content[0].content").value("Great game!"));
     }
 
@@ -79,7 +77,7 @@ class ReviewControllerTest {
     @DisplayName("POST /api/games/{gameId}/reviews should return 201 Created")
     void shouldSubmitReview() throws Exception {
         // Given
-        ReviewRequestDto request = new ReviewRequestDto(5, "Great game!", false);
+        ReviewRequestDto request = new ReviewRequestDto("Great game!", false);
         when(reviewService.addOrUpdateReview(any(), eq(gameId), any())).thenReturn(reviewResponseDto);
 
         // When & Then
@@ -87,7 +85,6 @@ class ReviewControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.score").value(5))
                 .andExpect(jsonPath("$.content").value("Great game!"));
     }
 
@@ -111,7 +108,6 @@ class ReviewControllerTest {
         // When & Then
         mockMvc.perform(get("/api/games/{gameId}/reviews/me", gameId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.score").value(5))
                 .andExpect(jsonPath("$.content").value("Great game!"));
     }
 

--- a/api/src/test/java/com/checkpoint/api/services/RateServiceImplTest.java
+++ b/api/src/test/java/com/checkpoint/api/services/RateServiceImplTest.java
@@ -1,0 +1,230 @@
+package com.checkpoint.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.checkpoint.api.dto.catalog.RateResponseDto;
+import com.checkpoint.api.entities.Rate;
+import com.checkpoint.api.entities.User;
+import com.checkpoint.api.entities.VideoGame;
+import com.checkpoint.api.exceptions.GameNotFoundException;
+import com.checkpoint.api.exceptions.RateNotFoundException;
+import com.checkpoint.api.mapper.RateMapper;
+import com.checkpoint.api.repositories.RateRepository;
+import com.checkpoint.api.repositories.UserRepository;
+import com.checkpoint.api.repositories.VideoGameRepository;
+import com.checkpoint.api.services.impl.RateServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class RateServiceImplTest {
+
+    @Mock
+    private RateRepository rateRepository;
+
+    @Mock
+    private VideoGameRepository videoGameRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RateMapper rateMapper;
+
+    private RateServiceImpl rateService;
+
+    private User testUser;
+    private VideoGame testGame;
+    private UUID gameId;
+
+    @BeforeEach
+    void setUp() {
+        rateService = new RateServiceImpl(rateRepository, videoGameRepository, userRepository, rateMapper);
+
+        gameId = UUID.randomUUID();
+
+        testUser = new User();
+        testUser.setId(UUID.randomUUID());
+        testUser.setPseudo("testuser");
+        testUser.setEmail("test@test.com");
+
+        testGame = new VideoGame();
+        testGame.setId(gameId);
+        testGame.setTitle("Test Game");
+        testGame.setAverageRating(0.0);
+    }
+
+    @Nested
+    @DisplayName("rateGame()")
+    class RateGame {
+
+        @Test
+        @DisplayName("Should create a new rating if none exists")
+        void rateGame_shouldCreateNewRating() {
+            // Given
+            when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
+            when(videoGameRepository.findById(gameId)).thenReturn(Optional.of(testGame));
+            when(rateRepository.findByUserEmailAndVideoGameId(testUser.getEmail(), gameId)).thenReturn(Optional.empty());
+
+            Rate savedRate = new Rate(testUser, testGame, 4);
+            savedRate.setId(UUID.randomUUID());
+            when(rateRepository.save(any(Rate.class))).thenReturn(savedRate);
+            when(rateRepository.calculateAverageRating(gameId)).thenReturn(4.0);
+
+            RateResponseDto responseDto = new RateResponseDto(savedRate.getId(), 4, gameId, null, null);
+            when(rateMapper.toDto(savedRate)).thenReturn(responseDto);
+
+            // When
+            RateResponseDto result = rateService.rateGame(testUser.getEmail(), gameId, 4);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.score()).isEqualTo(4);
+            assertThat(result.videoGameId()).isEqualTo(gameId);
+            verify(rateRepository).save(any(Rate.class));
+            verify(videoGameRepository).save(testGame);
+            assertThat(testGame.getAverageRating()).isEqualTo(4.0);
+        }
+
+        @Test
+        @DisplayName("Should update an existing rating")
+        void rateGame_shouldUpdateExistingRating() {
+            // Given
+            Rate existingRate = new Rate(testUser, testGame, 3);
+            existingRate.setId(UUID.randomUUID());
+
+            when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
+            when(videoGameRepository.findById(gameId)).thenReturn(Optional.of(testGame));
+            when(rateRepository.findByUserEmailAndVideoGameId(testUser.getEmail(), gameId)).thenReturn(Optional.of(existingRate));
+
+            when(rateRepository.save(existingRate)).thenReturn(existingRate);
+            when(rateRepository.calculateAverageRating(gameId)).thenReturn(5.0);
+
+            RateResponseDto responseDto = new RateResponseDto(existingRate.getId(), 5, gameId, null, null);
+            when(rateMapper.toDto(existingRate)).thenReturn(responseDto);
+
+            // When
+            RateResponseDto result = rateService.rateGame(testUser.getEmail(), gameId, 5);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.score()).isEqualTo(5);
+            assertThat(existingRate.getScore()).isEqualTo(5);
+            verify(rateRepository).save(existingRate);
+        }
+
+        @Test
+        @DisplayName("Should throw GameNotFoundException when game does not exist")
+        void rateGame_shouldThrowWhenGameNotFound() {
+            // Given
+            when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
+            when(videoGameRepository.findById(gameId)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> rateService.rateGame(testUser.getEmail(), gameId, 4))
+                    .isInstanceOf(GameNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when user not found")
+        void rateGame_shouldThrowWhenUserNotFound() {
+            // Given
+            when(userRepository.findByEmail("unknown@test.com")).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> rateService.rateGame("unknown@test.com", gameId, 4))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("removeRating()")
+    class RemoveRating {
+
+        @Test
+        @DisplayName("Should remove an existing rating and recalculate average")
+        void removeRating_shouldDeleteRating() {
+            // Given
+            Rate existingRate = new Rate(testUser, testGame, 4);
+            existingRate.setId(UUID.randomUUID());
+
+            when(rateRepository.findByUserEmailAndVideoGameId(testUser.getEmail(), gameId))
+                    .thenReturn(Optional.of(existingRate));
+            when(rateRepository.calculateAverageRating(gameId)).thenReturn(null);
+
+            // When
+            rateService.removeRating(testUser.getEmail(), gameId);
+
+            // Then
+            verify(rateRepository).delete(existingRate);
+            verify(videoGameRepository).save(testGame);
+            assertThat(testGame.getAverageRating()).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("Should throw RateNotFoundException when no rating exists")
+        void removeRating_shouldThrowWhenNoRatingExists() {
+            // Given
+            when(rateRepository.findByUserEmailAndVideoGameId(testUser.getEmail(), gameId))
+                    .thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> rateService.removeRating(testUser.getEmail(), gameId))
+                    .isInstanceOf(RateNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserRating()")
+    class GetUserRating {
+
+        @Test
+        @DisplayName("Should return rating when it exists")
+        void getUserRating_shouldReturnRating() {
+            // Given
+            Rate rate = new Rate(testUser, testGame, 4);
+            rate.setId(UUID.randomUUID());
+
+            when(rateRepository.findByUserEmailAndVideoGameId(testUser.getEmail(), gameId))
+                    .thenReturn(Optional.of(rate));
+
+            RateResponseDto responseDto = new RateResponseDto(rate.getId(), 4, gameId, null, null);
+            when(rateMapper.toDto(rate)).thenReturn(responseDto);
+
+            // When
+            RateResponseDto result = rateService.getUserRating(testUser.getEmail(), gameId);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.score()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("Should return null when no rating exists")
+        void getUserRating_shouldReturnNullWhenNoRatingExists() {
+            // Given
+            when(rateRepository.findByUserEmailAndVideoGameId(testUser.getEmail(), gameId))
+                    .thenReturn(Optional.empty());
+            when(rateMapper.toDto(null)).thenReturn(null);
+
+            // When
+            RateResponseDto result = rateService.getUserRating(testUser.getEmail(), gameId);
+
+            // Then
+            assertThat(result).isNull();
+        }
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/services/ReviewServiceImplTest.java
+++ b/api/src/test/java/com/checkpoint/api/services/ReviewServiceImplTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -30,7 +29,6 @@ import com.checkpoint.api.entities.User;
 import com.checkpoint.api.entities.VideoGame;
 import com.checkpoint.api.exceptions.GameNotFoundException;
 import com.checkpoint.api.mapper.ReviewMapper;
-import com.checkpoint.api.repositories.RateRepository;
 import com.checkpoint.api.repositories.ReviewRepository;
 import com.checkpoint.api.repositories.UserRepository;
 import com.checkpoint.api.repositories.VideoGameRepository;
@@ -43,9 +41,6 @@ class ReviewServiceImplTest {
     private ReviewRepository reviewRepository;
 
     @Mock
-    private RateRepository rateRepository;
-
-    @Mock
     private VideoGameRepository videoGameRepository;
 
     @Mock
@@ -54,7 +49,6 @@ class ReviewServiceImplTest {
     @Mock
     private ReviewMapper reviewMapper;
 
-    @InjectMocks
     private ReviewServiceImpl reviewService;
 
     private User testUser;
@@ -63,6 +57,8 @@ class ReviewServiceImplTest {
 
     @BeforeEach
     void setUp() {
+        reviewService = new ReviewServiceImpl(reviewRepository, videoGameRepository, userRepository, reviewMapper);
+
         gameId = UUID.randomUUID();
 
         testUser = new User();
@@ -73,7 +69,6 @@ class ReviewServiceImplTest {
         testGame = new VideoGame();
         testGame.setId(gameId);
         testGame.setTitle("Test Game");
-        testGame.setAverageRating(0.0);
     }
 
     @Nested
@@ -84,34 +79,25 @@ class ReviewServiceImplTest {
         @DisplayName("Should create a new review if none exists")
         void shouldCreateNewReview() {
             // Given
-            ReviewRequestDto requestDto = new ReviewRequestDto(5, "Great game!", false);
+            ReviewRequestDto requestDto = new ReviewRequestDto("Great game!", false);
             when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
             when(videoGameRepository.findById(gameId)).thenReturn(Optional.of(testGame));
             when(reviewRepository.findByUserPseudoAndVideoGameId(testUser.getPseudo(), gameId)).thenReturn(Optional.empty());
-            when(rateRepository.findByUserPseudoAndVideoGameId(testUser.getPseudo(), gameId)).thenReturn(Optional.empty());
-
-            com.checkpoint.api.entities.Rate rate = new com.checkpoint.api.entities.Rate(testUser, testGame, 5);
-            when(rateRepository.save(any(com.checkpoint.api.entities.Rate.class))).thenReturn(rate);
 
             Review savedReview = new Review("Great game!", false, testUser, testGame);
             savedReview.setId(UUID.randomUUID());
             when(reviewRepository.save(any(Review.class))).thenReturn(savedReview);
 
-            when(rateRepository.calculateAverageRating(gameId)).thenReturn(5.0);
-
-            ReviewResponseDto responseDto = new ReviewResponseDto(savedReview.getId(), 5, "Great game!", false, null, null, null);
-            when(reviewMapper.toDto(savedReview, 5)).thenReturn(responseDto);
+            ReviewResponseDto responseDto = new ReviewResponseDto(savedReview.getId(), "Great game!", false, null, null, null);
+            when(reviewMapper.toDto(savedReview)).thenReturn(responseDto);
 
             // When
             ReviewResponseDto result = reviewService.addOrUpdateReview(testUser.getEmail(), gameId, requestDto);
 
             // Then
             assertThat(result).isNotNull();
-            assertThat(result.score()).isEqualTo(5);
+            assertThat(result.content()).isEqualTo("Great game!");
             verify(reviewRepository).save(any(Review.class));
-            verify(rateRepository).save(any(com.checkpoint.api.entities.Rate.class));
-            verify(videoGameRepository).save(testGame);
-            assertThat(testGame.getAverageRating()).isEqualTo(5.0);
         }
 
         @Test
@@ -120,40 +106,32 @@ class ReviewServiceImplTest {
             // Given
             Review existingReview = new Review("Okay game", false, testUser, testGame);
             existingReview.setId(UUID.randomUUID());
-            com.checkpoint.api.entities.Rate existingRate = new com.checkpoint.api.entities.Rate(testUser, testGame, 3);
-            existingRate.setId(UUID.randomUUID());
 
-            ReviewRequestDto requestDto = new ReviewRequestDto(4, "Actually, it's better", true);
+            ReviewRequestDto requestDto = new ReviewRequestDto("Actually, it's better", true);
             when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
             when(videoGameRepository.findById(gameId)).thenReturn(Optional.of(testGame));
             when(reviewRepository.findByUserPseudoAndVideoGameId(testUser.getPseudo(), gameId)).thenReturn(Optional.of(existingReview));
-            when(rateRepository.findByUserPseudoAndVideoGameId(testUser.getPseudo(), gameId)).thenReturn(Optional.of(existingRate));
 
             when(reviewRepository.save(existingReview)).thenReturn(existingReview);
-            when(rateRepository.save(existingRate)).thenReturn(existingRate);
 
-            when(rateRepository.calculateAverageRating(gameId)).thenReturn(4.0);
-
-            ReviewResponseDto responseDto = new ReviewResponseDto(existingReview.getId(), 4, "Actually, it's better", true, null, null, null);
-            when(reviewMapper.toDto(existingReview, 4)).thenReturn(responseDto);
+            ReviewResponseDto responseDto = new ReviewResponseDto(existingReview.getId(), "Actually, it's better", true, null, null, null);
+            when(reviewMapper.toDto(existingReview)).thenReturn(responseDto);
 
             // When
             ReviewResponseDto result = reviewService.addOrUpdateReview(testUser.getEmail(), gameId, requestDto);
 
             // Then
             assertThat(result).isNotNull();
-            assertThat(result.score()).isEqualTo(4);
+            assertThat(result.content()).isEqualTo("Actually, it's better");
             assertThat(existingReview.getContent()).isEqualTo("Actually, it's better");
             verify(reviewRepository).save(existingReview);
-            verify(rateRepository).save(existingRate);
-            assertThat(testGame.getAverageRating()).isEqualTo(4.0);
         }
 
         @Test
         @DisplayName("Should throw GameNotFoundException when video game does not exist")
         void shouldThrowExceptionWhenGameNotFound() {
             // Given
-            ReviewRequestDto requestDto = new ReviewRequestDto(5, "Great game!", false);
+            ReviewRequestDto requestDto = new ReviewRequestDto("Great game!", false);
             when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
             when(videoGameRepository.findById(gameId)).thenReturn(Optional.empty());
 
@@ -174,14 +152,12 @@ class ReviewServiceImplTest {
             Pageable pageable = PageRequest.of(0, 10);
             Review review = new Review("Good", false, testUser, testGame);
             Page<Review> reviewPage = new PageImpl<>(List.of(review));
-            com.checkpoint.api.entities.Rate rate = new com.checkpoint.api.entities.Rate(testUser, testGame, 4);
 
             when(videoGameRepository.existsById(gameId)).thenReturn(true);
             when(reviewRepository.findByVideoGameId(gameId, pageable)).thenReturn(reviewPage);
-            when(rateRepository.findByVideoGameIdAndUserIdIn(gameId, java.util.List.of(testUser.getId()))).thenReturn(java.util.List.of(rate));
 
-            ReviewResponseDto responseDto = new ReviewResponseDto(UUID.randomUUID(), 4, "Good", false, null, null, null);
-            when(reviewMapper.toDto(review, 4)).thenReturn(responseDto);
+            ReviewResponseDto responseDto = new ReviewResponseDto(UUID.randomUUID(), "Good", false, null, null, null);
+            when(reviewMapper.toDto(review)).thenReturn(responseDto);
 
             // When
             Page<ReviewResponseDto> result = reviewService.getGameReviews(gameId, pageable);
@@ -189,7 +165,74 @@ class ReviewServiceImplTest {
             // Then
             assertThat(result).isNotNull();
             assertThat(result.getContent()).hasSize(1);
-            assertThat(result.getContent().get(0).score()).isEqualTo(4);
+            assertThat(result.getContent().get(0).content()).isEqualTo("Good");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteReview()")
+    class DeleteReview {
+
+        @Test
+        @DisplayName("Should delete a review without touching ratings")
+        void shouldDeleteReview() {
+            // Given
+            Review existingReview = new Review("Good", false, testUser, testGame);
+            existingReview.setId(UUID.randomUUID());
+
+            when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
+            when(reviewRepository.findByUserPseudoAndVideoGameId(testUser.getPseudo(), gameId))
+                    .thenReturn(Optional.of(existingReview));
+
+            // When
+            reviewService.deleteReview(testUser.getEmail(), gameId);
+
+            // Then
+            verify(reviewRepository).delete(existingReview);
+        }
+    }
+
+    @Nested
+    @DisplayName("getReviewByUserAndGame()")
+    class GetReviewByUserAndGame {
+
+        @Test
+        @DisplayName("Should return review when it exists")
+        void shouldReturnReviewWhenExists() {
+            // Given
+            Review review = new Review("Great game!", false, testUser, testGame);
+            review.setId(UUID.randomUUID());
+
+            when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
+            when(videoGameRepository.existsById(gameId)).thenReturn(true);
+            when(reviewRepository.findByUserPseudoAndVideoGameId(testUser.getPseudo(), gameId))
+                    .thenReturn(Optional.of(review));
+
+            ReviewResponseDto responseDto = new ReviewResponseDto(review.getId(), "Great game!", false, null, null, null);
+            when(reviewMapper.toDto(review)).thenReturn(responseDto);
+
+            // When
+            ReviewResponseDto result = reviewService.getReviewByUserAndGame(testUser.getEmail(), gameId);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.content()).isEqualTo("Great game!");
+        }
+
+        @Test
+        @DisplayName("Should return null when no review exists")
+        void shouldReturnNullWhenNoReviewExists() {
+            // Given
+            when(userRepository.findByEmail(testUser.getEmail())).thenReturn(Optional.of(testUser));
+            when(videoGameRepository.existsById(gameId)).thenReturn(true);
+            when(reviewRepository.findByUserPseudoAndVideoGameId(testUser.getPseudo(), gameId))
+                    .thenReturn(Optional.empty());
+
+            // When
+            ReviewResponseDto result = reviewService.getReviewByUserAndGame(testUser.getEmail(), gameId);
+
+            // Then
+            assertThat(result).isNull();
         }
     }
 }


### PR DESCRIPTION
Introduce independent PUT/GET/DELETE /api/me/games/{videoGameId}/rate endpoints so users can rate games without writing a review.
- Add RateController, RateService (interface + impl), RateMapper, RateRequestDto, RateResponseDto, and RateNotFoundException
- Move updateGameAverageRating logic from ReviewServiceImpl to RateServiceImpl
- Remove score field from ReviewRequestDto and ReviewResponseDto
- Remove RateRepository dependency from ReviewServiceImpl
- Add IgdbApiException handler to GlobalExceptionHandler as safety net
- Add Bruno collection files for rate endpoints
- Update review Bruno files to reflect score removal
- Add full test coverage for RateController and RateServiceImpl