### PR TITLE
feat(api,web): implement comments on reviews and game lists (TE-219)

### DIFF
--- a/api/bruno/comments/Delete Comment.bru
+++ b/api/bruno/comments/Delete Comment.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Delete Comment
+  type: http
+  seq: 2
+}
+
+delete {
+  url: {{baseUrl}}/api/comments/:commentId
+  body: none
+  auth: bearer
+}
+
+params:path {
+  commentId: 00000000-0000-0000-0000-000000000000
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  # Delete Comment
+
+  Deletes a comment. Only the comment owner can perform this action.
+
+  ## Authentication
+
+  Requires a valid JWT token in the `Authorization: Bearer` header.
+
+  ## Path Parameters
+
+  - **commentId**: The UUID of the comment to delete
+
+  ## Response (204 No Content)
+
+  Empty response body.
+
+  ## Error Responses
+
+  - **401 Unauthorized**: Not authenticated
+  - **403 Forbidden**: Not the comment owner
+  - **404 Not Found**: Comment does not exist
+}

--- a/api/bruno/comments/Update Comment.bru
+++ b/api/bruno/comments/Update Comment.bru
@@ -1,0 +1,72 @@
+meta {
+  name: Update Comment
+  type: http
+  seq: 1
+}
+
+put {
+  url: {{baseUrl}}/api/comments/:commentId
+  body: json
+  auth: bearer
+}
+
+params:path {
+  commentId: 00000000-0000-0000-0000-000000000000
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "content": "Updated comment content"
+  }
+}
+
+docs {
+  # Update Comment
+
+  Updates a comment. Only the comment owner can perform this action.
+
+  ## Authentication
+
+  Requires a valid JWT token in the `Authorization: Bearer` header.
+
+  ## Path Parameters
+
+  - **commentId**: The UUID of the comment to update
+
+  ## Request Body
+
+  ```json
+  {
+    "content": "Updated comment content"
+  }
+  ```
+
+  - **content** (required): The updated comment text (max 5000 characters)
+
+  ## Response (200 OK)
+
+  ```json
+  {
+    "id": "uuid",
+    "content": "Updated comment content",
+    "user": {
+      "id": "uuid",
+      "pseudo": "gamer123",
+      "picture": null
+    },
+    "createdAt": "2026-04-01T10:00:00",
+    "updatedAt": "2026-04-01T12:00:00"
+  }
+  ```
+
+  ## Error Responses
+
+  - **400 Bad Request**: Content is blank or exceeds 5000 characters
+  - **401 Unauthorized**: Not authenticated
+  - **403 Forbidden**: Not the comment owner
+  - **404 Not Found**: Comment does not exist
+}

--- a/api/bruno/comments/folder.bru
+++ b/api/bruno/comments/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: comments
+}

--- a/api/bruno/lists/Add List Comment.bru
+++ b/api/bruno/lists/Add List Comment.bru
@@ -1,0 +1,71 @@
+meta {
+  name: Add List Comment
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/lists/:listId/comments
+  body: json
+  auth: bearer
+}
+
+params:path {
+  listId: 00000000-0000-0000-0000-000000000000
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "content": "Awesome list, thanks for sharing!"
+  }
+}
+
+docs {
+  # Add List Comment
+
+  Adds a comment to a game list.
+
+  ## Authentication
+
+  Requires a valid JWT token in the `Authorization: Bearer` header.
+
+  ## Path Parameters
+
+  - **listId**: The UUID of the game list to comment on
+
+  ## Request Body
+
+  ```json
+  {
+    "content": "Awesome list, thanks for sharing!"
+  }
+  ```
+
+  - **content** (required): The comment text (max 5000 characters)
+
+  ## Response (201 Created)
+
+  ```json
+  {
+    "id": "uuid",
+    "content": "Awesome list, thanks for sharing!",
+    "user": {
+      "id": "uuid",
+      "pseudo": "gamer123",
+      "picture": null
+    },
+    "createdAt": "2026-04-01T10:00:00",
+    "updatedAt": "2026-04-01T10:00:00"
+  }
+  ```
+
+  ## Error Responses
+
+  - **400 Bad Request**: Content is blank or exceeds 5000 characters
+  - **401 Unauthorized**: Not authenticated
+  - **404 Not Found**: Game list does not exist
+}

--- a/api/bruno/lists/Get List Comments.bru
+++ b/api/bruno/lists/Get List Comments.bru
@@ -1,0 +1,63 @@
+meta {
+  name: Get List Comments
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/lists/:listId/comments?page=0&size=20
+  body: none
+  auth: none
+}
+
+params:query {
+  page: 0
+  size: 20
+}
+
+params:path {
+  listId: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  # Get List Comments
+
+  Retrieves a paginated list of comments for a game list, sorted by most recent first.
+
+  ## Path Parameters
+
+  - **listId**: The UUID of the game list
+
+  ## Query Parameters
+
+  - **page**: Page number (0-based, default: 0)
+  - **size**: Page size (default: 20, max: 100)
+
+  ## Response (200 OK)
+
+  ```json
+  {
+    "content": [
+      {
+        "id": "uuid",
+        "content": "Awesome list!",
+        "user": {
+          "id": "uuid",
+          "pseudo": "gamer123",
+          "picture": null
+        },
+        "createdAt": "2026-04-01T10:00:00",
+        "updatedAt": "2026-04-01T10:00:00"
+      }
+    ],
+    "metadata": {
+      "page": 0,
+      "size": 20,
+      "totalElements": 1,
+      "totalPages": 1,
+      "hasNext": false,
+      "hasPrevious": false
+    }
+  }
+  ```
+}

--- a/api/bruno/reviews/Add Review Comment.bru
+++ b/api/bruno/reviews/Add Review Comment.bru
@@ -1,0 +1,71 @@
+meta {
+  name: Add Review Comment
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/reviews/:reviewId/comments
+  body: json
+  auth: bearer
+}
+
+params:path {
+  reviewId: 00000000-0000-0000-0000-000000000000
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "content": "Great review, I totally agree!"
+  }
+}
+
+docs {
+  # Add Review Comment
+
+  Adds a comment to a review.
+
+  ## Authentication
+
+  Requires a valid JWT token in the `Authorization: Bearer` header.
+
+  ## Path Parameters
+
+  - **reviewId**: The UUID of the review to comment on
+
+  ## Request Body
+
+  ```json
+  {
+    "content": "Great review, I totally agree!"
+  }
+  ```
+
+  - **content** (required): The comment text (max 5000 characters)
+
+  ## Response (201 Created)
+
+  ```json
+  {
+    "id": "uuid",
+    "content": "Great review, I totally agree!",
+    "user": {
+      "id": "uuid",
+      "pseudo": "gamer123",
+      "picture": null
+    },
+    "createdAt": "2026-04-01T10:00:00",
+    "updatedAt": "2026-04-01T10:00:00"
+  }
+  ```
+
+  ## Error Responses
+
+  - **400 Bad Request**: Content is blank or exceeds 5000 characters
+  - **401 Unauthorized**: Not authenticated
+  - **404 Not Found**: Review does not exist
+}

--- a/api/bruno/reviews/Get Review Comments.bru
+++ b/api/bruno/reviews/Get Review Comments.bru
@@ -1,0 +1,63 @@
+meta {
+  name: Get Review Comments
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/reviews/:reviewId/comments?page=0&size=20
+  body: none
+  auth: none
+}
+
+params:query {
+  page: 0
+  size: 20
+}
+
+params:path {
+  reviewId: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  # Get Review Comments
+
+  Retrieves a paginated list of comments for a review, sorted by most recent first.
+
+  ## Path Parameters
+
+  - **reviewId**: The UUID of the review
+
+  ## Query Parameters
+
+  - **page**: Page number (0-based, default: 0)
+  - **size**: Page size (default: 20, max: 100)
+
+  ## Response (200 OK)
+
+  ```json
+  {
+    "content": [
+      {
+        "id": "uuid",
+        "content": "Great review!",
+        "user": {
+          "id": "uuid",
+          "pseudo": "gamer123",
+          "picture": null
+        },
+        "createdAt": "2026-04-01T10:00:00",
+        "updatedAt": "2026-04-01T10:00:00"
+      }
+    ],
+    "metadata": {
+      "page": 0,
+      "size": 20,
+      "totalElements": 1,
+      "totalPages": 1,
+      "hasNext": false,
+      "hasPrevious": false
+    }
+  }
+  ```
+}

--- a/api/src/main/java/com/checkpoint/api/config/SecurityConfig.java
+++ b/api/src/main/java/com/checkpoint/api/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/platforms").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/users/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/reviews/*/comments").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/lists/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())

--- a/api/src/main/java/com/checkpoint/api/controllers/CommentController.java
+++ b/api/src/main/java/com/checkpoint/api/controllers/CommentController.java
@@ -1,0 +1,196 @@
+package com.checkpoint.api.controllers;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.checkpoint.api.dto.catalog.PagedResponseDto;
+import com.checkpoint.api.dto.social.CommentRequestDto;
+import com.checkpoint.api.dto.social.CommentResponseDto;
+import com.checkpoint.api.services.CommentService;
+
+import jakarta.validation.Valid;
+
+/**
+ * REST controller for comments on reviews and game lists.
+ * GET endpoints are public; POST/PUT/DELETE require authentication.
+ */
+@RestController
+public class CommentController {
+
+    private static final Logger log = LoggerFactory.getLogger(CommentController.class);
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final CommentService commentService;
+
+    /**
+     * Constructs a new CommentController.
+     *
+     * @param commentService the comment service
+     */
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    /**
+     * Retrieves a paginated list of comments for a review.
+     *
+     * @param reviewId the review ID
+     * @param page     the page number (0-based)
+     * @param size     the page size
+     * @return the paginated comments
+     */
+    @GetMapping("/api/reviews/{reviewId}/comments")
+    public ResponseEntity<PagedResponseDto<CommentResponseDto>> getReviewComments(
+            @PathVariable UUID reviewId,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+
+        log.info("GET /api/reviews/{}/comments - page: {}, size: {}", reviewId, page, size);
+
+        Pageable pageable = createPageable(page, size);
+        Page<CommentResponseDto> comments = commentService.getReviewComments(reviewId, pageable);
+
+        return ResponseEntity.ok(PagedResponseDto.from(comments));
+    }
+
+    /**
+     * Adds a comment to a review.
+     *
+     * @param userDetails the authenticated user principal
+     * @param reviewId    the review ID
+     * @param request     the comment request body
+     * @return the created comment
+     */
+    @PostMapping("/api/reviews/{reviewId}/comments")
+    public ResponseEntity<CommentResponseDto> addReviewComment(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID reviewId,
+            @Valid @RequestBody CommentRequestDto request) {
+
+        log.info("POST /api/reviews/{}/comments - user: {}", reviewId, userDetails.getUsername());
+
+        CommentResponseDto response = commentService.addReviewComment(
+                userDetails.getUsername(), reviewId, request.content());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Retrieves a paginated list of comments for a game list.
+     *
+     * @param listId the game list ID
+     * @param page   the page number (0-based)
+     * @param size   the page size
+     * @return the paginated comments
+     */
+    @GetMapping("/api/lists/{listId}/comments")
+    public ResponseEntity<PagedResponseDto<CommentResponseDto>> getListComments(
+            @PathVariable UUID listId,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+
+        log.info("GET /api/lists/{}/comments - page: {}, size: {}", listId, page, size);
+
+        Pageable pageable = createPageable(page, size);
+        Page<CommentResponseDto> comments = commentService.getListComments(listId, pageable);
+
+        return ResponseEntity.ok(PagedResponseDto.from(comments));
+    }
+
+    /**
+     * Adds a comment to a game list.
+     *
+     * @param userDetails the authenticated user principal
+     * @param listId      the game list ID
+     * @param request     the comment request body
+     * @return the created comment
+     */
+    @PostMapping("/api/lists/{listId}/comments")
+    public ResponseEntity<CommentResponseDto> addListComment(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID listId,
+            @Valid @RequestBody CommentRequestDto request) {
+
+        log.info("POST /api/lists/{}/comments - user: {}", listId, userDetails.getUsername());
+
+        CommentResponseDto response = commentService.addListComment(
+                userDetails.getUsername(), listId, request.content());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Updates a comment. Only the comment owner can perform this action.
+     *
+     * @param userDetails the authenticated user principal
+     * @param commentId   the comment ID
+     * @param request     the comment request body with updated content
+     * @return the updated comment
+     */
+    @PutMapping("/api/comments/{commentId}")
+    public ResponseEntity<CommentResponseDto> updateComment(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID commentId,
+            @Valid @RequestBody CommentRequestDto request) {
+
+        log.info("PUT /api/comments/{} - user: {}", commentId, userDetails.getUsername());
+
+        CommentResponseDto response = commentService.updateComment(
+                userDetails.getUsername(), commentId, request.content());
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Deletes a comment. Only the comment owner can perform this action.
+     *
+     * @param userDetails the authenticated user principal
+     * @param commentId   the comment ID
+     * @return 204 No Content
+     */
+    @DeleteMapping("/api/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID commentId) {
+
+        log.info("DELETE /api/comments/{} - user: {}", commentId, userDetails.getUsername());
+
+        commentService.deleteComment(userDetails.getUsername(), commentId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Creates a Pageable with default sort by createdAt descending.
+     *
+     * @param page the page number
+     * @param size the page size
+     * @return a Pageable instance
+     */
+    private Pageable createPageable(int page, int size) {
+        int validatedPage = Math.max(0, page);
+        int validatedSize = Math.min(Math.max(1, size), MAX_SIZE);
+        return PageRequest.of(validatedPage, validatedSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/controllers/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/checkpoint/api/controllers/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.checkpoint.api.exceptions.CommentNotFoundException;
 import com.checkpoint.api.exceptions.GameAlreadyInListException;
 import com.checkpoint.api.exceptions.GameListNotFoundException;
 import com.checkpoint.api.exceptions.GameNotInListException;
@@ -36,6 +37,7 @@ import com.checkpoint.api.exceptions.RateNotFoundException;
 import com.checkpoint.api.exceptions.ReviewAlreadyExistsException;
 import com.checkpoint.api.exceptions.ReviewNotFoundException;
 import com.checkpoint.api.exceptions.SelfFollowException;
+import com.checkpoint.api.exceptions.UnauthorizedCommentAccessException;
 import com.checkpoint.api.exceptions.UnauthorizedListAccessException;
 import com.checkpoint.api.exceptions.UserNotFoundException;
 
@@ -66,6 +68,46 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    /**
+     * Handles CommentNotFoundException when a comment is not found.
+     *
+     * @param ex the exception
+     * @return error response with 404 status
+     */
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCommentNotFound(CommentNotFoundException ex) {
+        log.warn("Comment not found: {}", ex.getMessage());
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                "Not Found",
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    /**
+     * Handles UnauthorizedCommentAccessException when a user tries to modify or delete a comment they do not own.
+     *
+     * @param ex the exception
+     * @return error response with 403 status
+     */
+    @ExceptionHandler(UnauthorizedCommentAccessException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedCommentAccess(UnauthorizedCommentAccessException ex) {
+        log.warn("Unauthorized comment access: {}", ex.getMessage());
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.FORBIDDEN.value(),
+                "Forbidden",
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
     }
 
     /**

--- a/api/src/main/java/com/checkpoint/api/dto/catalog/ReviewResponseDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/catalog/ReviewResponseDto.java
@@ -23,6 +23,7 @@ public record ReviewResponseDto(
     PlayStatus playStatus,
     Boolean isReplay,
     long likesCount,
-    boolean hasLiked
+    boolean hasLiked,
+    long commentsCount
 ) {
 }

--- a/api/src/main/java/com/checkpoint/api/dto/list/GameListCardDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/list/GameListCardDto.java
@@ -14,6 +14,7 @@ public record GameListCardDto(
         Boolean isPrivate,
         Integer videoGamesCount,
         Long likesCount,
+        Long commentsCount,
         String authorPseudo,
         String authorPicture,
         List<String> coverUrls,

--- a/api/src/main/java/com/checkpoint/api/dto/list/GameListDetailDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/list/GameListDetailDto.java
@@ -15,6 +15,7 @@ public record GameListDetailDto(
         Boolean isPrivate,
         Integer videoGamesCount,
         Long likesCount,
+        Long commentsCount,
         String authorPseudo,
         String authorPicture,
         List<GameListEntryDto> entries,

--- a/api/src/main/java/com/checkpoint/api/dto/social/CommentRequestDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/social/CommentRequestDto.java
@@ -1,0 +1,15 @@
+package com.checkpoint.api.dto.social;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for creating or updating a comment.
+ *
+ * @param content the comment text content
+ */
+public record CommentRequestDto(
+        @NotBlank(message = "Comment content must not be blank")
+        @Size(max = 5000, message = "Comment content must not exceed 5000 characters")
+        String content
+) {}

--- a/api/src/main/java/com/checkpoint/api/dto/social/CommentResponseDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/social/CommentResponseDto.java
@@ -1,0 +1,21 @@
+package com.checkpoint.api.dto.social;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * DTO representing a comment returned to the client.
+ *
+ * @param id        the comment ID
+ * @param content   the comment text content
+ * @param user      the comment author
+ * @param createdAt when the comment was created
+ * @param updatedAt when the comment was last updated
+ */
+public record CommentResponseDto(
+        UUID id,
+        String content,
+        CommentUserDto user,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/api/src/main/java/com/checkpoint/api/dto/social/CommentUserDto.java
+++ b/api/src/main/java/com/checkpoint/api/dto/social/CommentUserDto.java
@@ -1,0 +1,16 @@
+package com.checkpoint.api.dto.social;
+
+import java.util.UUID;
+
+/**
+ * DTO containing basic user information for a comment.
+ *
+ * @param id      the user ID
+ * @param pseudo  the user's display name
+ * @param picture the user's profile picture URL
+ */
+public record CommentUserDto(
+        UUID id,
+        String pseudo,
+        String picture
+) {}

--- a/api/src/main/java/com/checkpoint/api/exceptions/CommentNotFoundException.java
+++ b/api/src/main/java/com/checkpoint/api/exceptions/CommentNotFoundException.java
@@ -1,0 +1,20 @@
+package com.checkpoint.api.exceptions;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a comment is not found.
+ */
+public class CommentNotFoundException extends RuntimeException {
+
+    private final UUID commentId;
+
+    public CommentNotFoundException(UUID commentId) {
+        super("Comment not found with ID: " + commentId);
+        this.commentId = commentId;
+    }
+
+    public UUID getCommentId() {
+        return commentId;
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/exceptions/UnauthorizedCommentAccessException.java
+++ b/api/src/main/java/com/checkpoint/api/exceptions/UnauthorizedCommentAccessException.java
@@ -1,0 +1,20 @@
+package com.checkpoint.api.exceptions;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a user tries to modify or delete a comment they do not own.
+ */
+public class UnauthorizedCommentAccessException extends RuntimeException {
+
+    private final UUID commentId;
+
+    public UnauthorizedCommentAccessException(UUID commentId) {
+        super("You do not have permission to modify comment with ID: " + commentId);
+        this.commentId = commentId;
+    }
+
+    public UUID getCommentId() {
+        return commentId;
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/mapper/CommentMapper.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/CommentMapper.java
@@ -1,0 +1,18 @@
+package com.checkpoint.api.mapper;
+
+import com.checkpoint.api.dto.social.CommentResponseDto;
+import com.checkpoint.api.entities.Comment;
+
+/**
+ * Mapper for converting Comment entities to DTOs.
+ */
+public interface CommentMapper {
+
+    /**
+     * Maps a Comment entity to a CommentResponseDto.
+     *
+     * @param comment the comment entity
+     * @return the comment response DTO
+     */
+    CommentResponseDto toDto(Comment comment);
+}

--- a/api/src/main/java/com/checkpoint/api/mapper/GameListMapper.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/GameListMapper.java
@@ -16,25 +16,27 @@ public interface GameListMapper {
     /**
      * Converts a GameList entity to a card DTO for browse/listing views.
      *
-     * @param gameList   the game list entity
-     * @param likesCount the number of likes for this list
-     * @param coverUrls  cover URLs of the first games in the list (max 4)
+     * @param gameList      the game list entity
+     * @param likesCount    the number of likes for this list
+     * @param commentsCount the number of comments for this list
+     * @param coverUrls     cover URLs of the first games in the list (max 4)
      * @return the card DTO
      */
-    GameListCardDto toCardDto(GameList gameList, long likesCount, List<String> coverUrls);
+    GameListCardDto toCardDto(GameList gameList, long likesCount, long commentsCount, List<String> coverUrls);
 
     /**
      * Converts a GameList entity to a detail DTO.
      *
-     * @param gameList   the game list entity
-     * @param entries    the ordered list entries with fetched video games
-     * @param likesCount the number of likes for this list
-     * @param isOwner    whether the viewer owns this list
-     * @param hasLiked   whether the viewer has liked this list
+     * @param gameList      the game list entity
+     * @param entries       the ordered list entries with fetched video games
+     * @param likesCount    the number of likes for this list
+     * @param commentsCount the number of comments for this list
+     * @param isOwner       whether the viewer owns this list
+     * @param hasLiked      whether the viewer has liked this list
      * @return the detail DTO
      */
     GameListDetailDto toDetailDto(GameList gameList, List<GameListEntry> entries,
-                                  long likesCount, boolean isOwner, boolean hasLiked);
+                                  long likesCount, long commentsCount, boolean isOwner, boolean hasLiked);
 
     /**
      * Converts a GameListEntry entity to an entry DTO.

--- a/api/src/main/java/com/checkpoint/api/mapper/ReviewMapper.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/ReviewMapper.java
@@ -17,12 +17,13 @@ public interface ReviewMapper {
     ReviewResponseDto toDto(Review review);
 
     /**
-     * Maps a Review entity to a ReviewResponseDto with like context.
+     * Maps a Review entity to a ReviewResponseDto with like and comment context.
      *
-     * @param review     the review entity
-     * @param likesCount the number of likes on this review
-     * @param hasLiked   whether the current viewer has liked this review
+     * @param review        the review entity
+     * @param likesCount    the number of likes on this review
+     * @param hasLiked      whether the current viewer has liked this review
+     * @param commentsCount the number of comments on this review
      * @return the review response DTO
      */
-    ReviewResponseDto toDto(Review review, long likesCount, boolean hasLiked);
+    ReviewResponseDto toDto(Review review, long likesCount, boolean hasLiked, long commentsCount);
 }

--- a/api/src/main/java/com/checkpoint/api/mapper/impl/CommentMapperImpl.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/impl/CommentMapperImpl.java
@@ -1,0 +1,44 @@
+package com.checkpoint.api.mapper.impl;
+
+import org.springframework.stereotype.Component;
+
+import com.checkpoint.api.dto.social.CommentResponseDto;
+import com.checkpoint.api.dto.social.CommentUserDto;
+import com.checkpoint.api.entities.Comment;
+import com.checkpoint.api.entities.User;
+import com.checkpoint.api.mapper.CommentMapper;
+
+/**
+ * Implementation of {@link CommentMapper}.
+ */
+@Component
+public class CommentMapperImpl implements CommentMapper {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CommentResponseDto toDto(Comment comment) {
+        if (comment == null) {
+            return null;
+        }
+
+        CommentUserDto userDto = null;
+        if (comment.getUser() != null) {
+            User user = comment.getUser();
+            userDto = new CommentUserDto(
+                    user.getId(),
+                    user.getPseudo(),
+                    user.getPicture()
+            );
+        }
+
+        return new CommentResponseDto(
+                comment.getId(),
+                comment.getContent(),
+                userDto,
+                comment.getCreatedAt(),
+                comment.getUpdatedAt()
+        );
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/mapper/impl/GameListMapperImpl.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/impl/GameListMapperImpl.java
@@ -20,7 +20,7 @@ import com.checkpoint.api.mapper.GameListMapper;
 public class GameListMapperImpl implements GameListMapper {
 
     @Override
-    public GameListCardDto toCardDto(GameList gameList, long likesCount, List<String> coverUrls) {
+    public GameListCardDto toCardDto(GameList gameList, long likesCount, long commentsCount, List<String> coverUrls) {
         User author = gameList.getUser();
 
         return new GameListCardDto(
@@ -30,6 +30,7 @@ public class GameListMapperImpl implements GameListMapper {
                 gameList.getIsPrivate(),
                 gameList.getVideoGamesCount(),
                 likesCount,
+                commentsCount,
                 author.getPseudo(),
                 author.getPicture(),
                 coverUrls,
@@ -39,7 +40,7 @@ public class GameListMapperImpl implements GameListMapper {
 
     @Override
     public GameListDetailDto toDetailDto(GameList gameList, List<GameListEntry> entries,
-                                         long likesCount, boolean isOwner, boolean hasLiked) {
+                                         long likesCount, long commentsCount, boolean isOwner, boolean hasLiked) {
         User author = gameList.getUser();
         List<GameListEntryDto> entryDtos = entries.stream()
                 .map(this::toEntryDto)
@@ -52,6 +53,7 @@ public class GameListMapperImpl implements GameListMapper {
                 gameList.getIsPrivate(),
                 gameList.getVideoGamesCount(),
                 likesCount,
+                commentsCount,
                 author.getPseudo(),
                 author.getPicture(),
                 entryDtos,

--- a/api/src/main/java/com/checkpoint/api/mapper/impl/ReviewMapperImpl.java
+++ b/api/src/main/java/com/checkpoint/api/mapper/impl/ReviewMapperImpl.java
@@ -23,14 +23,14 @@ public class ReviewMapperImpl implements ReviewMapper {
      */
     @Override
     public ReviewResponseDto toDto(Review review) {
-        return toDto(review, 0, false);
+        return toDto(review, 0, false, 0);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ReviewResponseDto toDto(Review review, long likesCount, boolean hasLiked) {
+    public ReviewResponseDto toDto(Review review, long likesCount, boolean hasLiked, long commentsCount) {
         if (review == null) {
             return null;
         }
@@ -70,7 +70,8 @@ public class ReviewMapperImpl implements ReviewMapper {
                 playStatus,
                 isReplay,
                 likesCount,
-                hasLiked
+                hasLiked,
+                commentsCount
         );
     }
 }

--- a/api/src/main/java/com/checkpoint/api/repositories/CommentRepository.java
+++ b/api/src/main/java/com/checkpoint/api/repositories/CommentRepository.java
@@ -1,0 +1,51 @@
+package com.checkpoint.api.repositories;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.checkpoint.api.entities.Comment;
+
+/**
+ * Repository for {@link Comment} entity.
+ */
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, UUID> {
+
+    /**
+     * Finds all comments for a specific review.
+     *
+     * @param reviewId the review ID
+     * @param pageable pagination and sorting details
+     * @return a page of comments
+     */
+    Page<Comment> findByReviewId(UUID reviewId, Pageable pageable);
+
+    /**
+     * Finds all comments for a specific game list.
+     *
+     * @param gameListId the game list ID
+     * @param pageable   pagination and sorting details
+     * @return a page of comments
+     */
+    Page<Comment> findByGameListId(UUID gameListId, Pageable pageable);
+
+    /**
+     * Counts the number of comments for a review.
+     *
+     * @param reviewId the review ID
+     * @return the comment count
+     */
+    long countByReviewId(UUID reviewId);
+
+    /**
+     * Counts the number of comments for a game list.
+     *
+     * @param gameListId the game list ID
+     * @return the comment count
+     */
+    long countByGameListId(UUID gameListId);
+}

--- a/api/src/main/java/com/checkpoint/api/services/CommentService.java
+++ b/api/src/main/java/com/checkpoint/api/services/CommentService.java
@@ -1,0 +1,76 @@
+package com.checkpoint.api.services;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.checkpoint.api.dto.social.CommentResponseDto;
+
+/**
+ * Service for managing comments on reviews and game lists.
+ */
+public interface CommentService {
+
+    /**
+     * Adds a comment to a review.
+     *
+     * @param userEmail the authenticated user's email
+     * @param reviewId  the review ID
+     * @param content   the comment text content
+     * @return the created comment
+     * @throws com.checkpoint.api.exceptions.ReviewNotFoundException if the review does not exist
+     */
+    CommentResponseDto addReviewComment(String userEmail, UUID reviewId, String content);
+
+    /**
+     * Adds a comment to a game list.
+     *
+     * @param userEmail the authenticated user's email
+     * @param listId    the game list ID
+     * @param content   the comment text content
+     * @return the created comment
+     * @throws com.checkpoint.api.exceptions.GameListNotFoundException if the game list does not exist
+     */
+    CommentResponseDto addListComment(String userEmail, UUID listId, String content);
+
+    /**
+     * Retrieves a paginated list of comments for a review.
+     *
+     * @param reviewId the review ID
+     * @param pageable pagination and sorting details
+     * @return a page of comments
+     */
+    Page<CommentResponseDto> getReviewComments(UUID reviewId, Pageable pageable);
+
+    /**
+     * Retrieves a paginated list of comments for a game list.
+     *
+     * @param listId   the game list ID
+     * @param pageable pagination and sorting details
+     * @return a page of comments
+     */
+    Page<CommentResponseDto> getListComments(UUID listId, Pageable pageable);
+
+    /**
+     * Updates a comment. Only the comment owner can perform this action.
+     *
+     * @param userEmail the authenticated user's email
+     * @param commentId the comment ID
+     * @param content   the updated comment text content
+     * @return the updated comment
+     * @throws com.checkpoint.api.exceptions.CommentNotFoundException          if the comment does not exist
+     * @throws com.checkpoint.api.exceptions.UnauthorizedCommentAccessException if the user is not the comment owner
+     */
+    CommentResponseDto updateComment(String userEmail, UUID commentId, String content);
+
+    /**
+     * Deletes a comment. Only the comment owner can perform this action.
+     *
+     * @param userEmail the authenticated user's email
+     * @param commentId the comment ID
+     * @throws com.checkpoint.api.exceptions.CommentNotFoundException          if the comment does not exist
+     * @throws com.checkpoint.api.exceptions.UnauthorizedCommentAccessException if the user is not the comment owner
+     */
+    void deleteComment(String userEmail, UUID commentId);
+}

--- a/api/src/main/java/com/checkpoint/api/services/impl/CommentServiceImpl.java
+++ b/api/src/main/java/com/checkpoint/api/services/impl/CommentServiceImpl.java
@@ -1,0 +1,173 @@
+package com.checkpoint.api.services.impl;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.checkpoint.api.dto.social.CommentResponseDto;
+import com.checkpoint.api.entities.Comment;
+import com.checkpoint.api.entities.GameList;
+import com.checkpoint.api.entities.Review;
+import com.checkpoint.api.entities.User;
+import com.checkpoint.api.exceptions.CommentNotFoundException;
+import com.checkpoint.api.exceptions.GameListNotFoundException;
+import com.checkpoint.api.exceptions.ReviewNotFoundException;
+import com.checkpoint.api.exceptions.UnauthorizedCommentAccessException;
+import com.checkpoint.api.mapper.CommentMapper;
+import com.checkpoint.api.repositories.CommentRepository;
+import com.checkpoint.api.repositories.GameListRepository;
+import com.checkpoint.api.repositories.ReviewRepository;
+import com.checkpoint.api.repositories.UserRepository;
+import com.checkpoint.api.services.CommentService;
+
+/**
+ * Implementation of {@link CommentService}.
+ * Manages CRUD operations for comments on reviews and game lists.
+ */
+@Service
+@Transactional
+public class CommentServiceImpl implements CommentService {
+
+    private static final Logger log = LoggerFactory.getLogger(CommentServiceImpl.class);
+
+    private final CommentRepository commentRepository;
+    private final ReviewRepository reviewRepository;
+    private final GameListRepository gameListRepository;
+    private final UserRepository userRepository;
+    private final CommentMapper commentMapper;
+
+    /**
+     * Constructs a new CommentServiceImpl.
+     *
+     * @param commentRepository  the comment repository
+     * @param reviewRepository   the review repository
+     * @param gameListRepository the game list repository
+     * @param userRepository     the user repository
+     * @param commentMapper      the comment mapper
+     */
+    public CommentServiceImpl(CommentRepository commentRepository,
+                              ReviewRepository reviewRepository,
+                              GameListRepository gameListRepository,
+                              UserRepository userRepository,
+                              CommentMapper commentMapper) {
+        this.commentRepository = commentRepository;
+        this.reviewRepository = reviewRepository;
+        this.gameListRepository = gameListRepository;
+        this.userRepository = userRepository;
+        this.commentMapper = commentMapper;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CommentResponseDto addReviewComment(String userEmail, UUID reviewId, String content) {
+        User user = getUserByEmail(userEmail);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException("Review not found with ID: " + reviewId));
+
+        Comment comment = Comment.onReview(content, user, review);
+        Comment savedComment = commentRepository.save(comment);
+
+        log.info("User {} commented on review {}", user.getPseudo(), reviewId);
+
+        return commentMapper.toDto(savedComment);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CommentResponseDto addListComment(String userEmail, UUID listId, String content) {
+        User user = getUserByEmail(userEmail);
+
+        GameList gameList = gameListRepository.findById(listId)
+                .orElseThrow(() -> new GameListNotFoundException(listId));
+
+        Comment comment = Comment.onList(content, user, gameList);
+        Comment savedComment = commentRepository.save(comment);
+
+        log.info("User {} commented on list {}", user.getPseudo(), listId);
+
+        return commentMapper.toDto(savedComment);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CommentResponseDto> getReviewComments(UUID reviewId, Pageable pageable) {
+        Page<Comment> comments = commentRepository.findByReviewId(reviewId, pageable);
+        return comments.map(commentMapper::toDto);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CommentResponseDto> getListComments(UUID listId, Pageable pageable) {
+        Page<Comment> comments = commentRepository.findByGameListId(listId, pageable);
+        return comments.map(commentMapper::toDto);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CommentResponseDto updateComment(String userEmail, UUID commentId, String content) {
+        User user = getUserByEmail(userEmail);
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new UnauthorizedCommentAccessException(commentId);
+        }
+
+        comment.setContent(content);
+        Comment updatedComment = commentRepository.save(comment);
+
+        log.info("User {} updated comment {}", user.getPseudo(), commentId);
+
+        return commentMapper.toDto(updatedComment);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void deleteComment(String userEmail, UUID commentId) {
+        User user = getUserByEmail(userEmail);
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new UnauthorizedCommentAccessException(commentId);
+        }
+
+        commentRepository.delete(comment);
+
+        log.info("User {} deleted comment {}", user.getPseudo(), commentId);
+    }
+
+    /**
+     * Retrieves a user by email.
+     *
+     * @param email the user's email
+     * @return the user entity
+     * @throws IllegalArgumentException if the user is not found
+     */
+    private User getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Authenticated user not found"));
+    }
+}

--- a/api/src/main/java/com/checkpoint/api/services/impl/GameListServiceImpl.java
+++ b/api/src/main/java/com/checkpoint/api/services/impl/GameListServiceImpl.java
@@ -26,6 +26,7 @@ import com.checkpoint.api.exceptions.GameNotFoundException;
 import com.checkpoint.api.exceptions.GameNotInListException;
 import com.checkpoint.api.exceptions.UnauthorizedListAccessException;
 import com.checkpoint.api.mapper.GameListMapper;
+import com.checkpoint.api.repositories.CommentRepository;
 import com.checkpoint.api.repositories.GameListEntryRepository;
 import com.checkpoint.api.repositories.GameListRepository;
 import com.checkpoint.api.repositories.LikeRepository;
@@ -47,6 +48,7 @@ public class GameListServiceImpl implements GameListService {
     private final UserRepository userRepository;
     private final VideoGameRepository videoGameRepository;
     private final LikeRepository likeRepository;
+    private final CommentRepository commentRepository;
     private final GameListMapper gameListMapper;
 
     public GameListServiceImpl(GameListRepository gameListRepository,
@@ -54,12 +56,14 @@ public class GameListServiceImpl implements GameListService {
                                UserRepository userRepository,
                                VideoGameRepository videoGameRepository,
                                LikeRepository likeRepository,
+                               CommentRepository commentRepository,
                                GameListMapper gameListMapper) {
         this.gameListRepository = gameListRepository;
         this.gameListEntryRepository = gameListEntryRepository;
         this.userRepository = userRepository;
         this.videoGameRepository = videoGameRepository;
         this.likeRepository = likeRepository;
+        this.commentRepository = commentRepository;
         this.gameListMapper = gameListMapper;
     }
 
@@ -76,7 +80,7 @@ public class GameListServiceImpl implements GameListService {
         GameList saved = gameListRepository.save(gameList);
 
         log.info("List '{}' created with ID {} for user {}", saved.getTitle(), saved.getId(), userEmail);
-        return gameListMapper.toDetailDto(saved, List.of(), 0L, true, false);
+        return gameListMapper.toDetailDto(saved, List.of(), 0L, 0L, true, false);
     }
 
     @Override
@@ -101,8 +105,10 @@ public class GameListServiceImpl implements GameListService {
         List<GameListEntry> entries = gameListEntryRepository.findByGameListIdOrderByPositionAsc(listId);
         long likesCount = likeRepository.countByGameListId(listId);
 
+        long commentsCount = commentRepository.countByGameListId(listId);
+
         log.info("List '{}' updated for user {}", updated.getTitle(), userEmail);
-        return gameListMapper.toDetailDto(updated, entries, likesCount, true, false);
+        return gameListMapper.toDetailDto(updated, entries, likesCount, commentsCount, true, false);
     }
 
     @Override
@@ -150,8 +156,10 @@ public class GameListServiceImpl implements GameListService {
         List<GameListEntry> entries = gameListEntryRepository.findByGameListIdOrderByPositionAsc(listId);
         long likesCount = likeRepository.countByGameListId(listId);
 
+        long commentsCount = commentRepository.countByGameListId(listId);
+
         log.info("Game '{}' added to list '{}' at position {}", videoGame.getTitle(), gameList.getTitle(), entry.getPosition());
-        return gameListMapper.toDetailDto(gameList, entries, likesCount, true, false);
+        return gameListMapper.toDetailDto(gameList, entries, likesCount, commentsCount, true, false);
     }
 
     @Override
@@ -199,8 +207,10 @@ public class GameListServiceImpl implements GameListService {
         List<GameListEntry> entries = gameListEntryRepository.findByGameListIdOrderByPositionAsc(listId);
         long likesCount = likeRepository.countByGameListId(listId);
 
+        long commentsCount = commentRepository.countByGameListId(listId);
+
         log.info("Games reordered in list '{}'", gameList.getTitle());
-        return gameListMapper.toDetailDto(gameList, entries, likesCount, true, false);
+        return gameListMapper.toDetailDto(gameList, entries, likesCount, commentsCount, true, false);
     }
 
     @Override
@@ -249,8 +259,9 @@ public class GameListServiceImpl implements GameListService {
 
         List<GameListEntry> entries = gameListEntryRepository.findByGameListIdOrderByPositionAsc(listId);
         long likesCount = likeRepository.countByGameListId(listId);
+        long commentsCount = commentRepository.countByGameListId(listId);
 
-        return gameListMapper.toDetailDto(gameList, entries, likesCount, isOwner, hasLiked);
+        return gameListMapper.toDetailDto(gameList, entries, likesCount, commentsCount, isOwner, hasLiked);
     }
 
     @Override
@@ -283,11 +294,12 @@ public class GameListServiceImpl implements GameListService {
 
     private GameListCardDto toCardDtoWithLikes(GameList gameList) {
         long likesCount = likeRepository.countByGameListId(gameList.getId());
+        long commentsCount = commentRepository.countByGameListId(gameList.getId());
         List<GameListEntry> entries = gameListEntryRepository.findByGameListIdOrderByPositionAsc(gameList.getId());
         List<String> coverUrls = entries.stream()
                 .limit(4)
                 .map(entry -> entry.getVideoGame().getCoverUrl())
                 .toList();
-        return gameListMapper.toCardDto(gameList, likesCount, coverUrls);
+        return gameListMapper.toCardDto(gameList, likesCount, commentsCount, coverUrls);
     }
 }

--- a/api/src/main/java/com/checkpoint/api/services/impl/ReviewServiceImpl.java
+++ b/api/src/main/java/com/checkpoint/api/services/impl/ReviewServiceImpl.java
@@ -22,6 +22,7 @@ import com.checkpoint.api.exceptions.PlayLogNotFoundException;
 import com.checkpoint.api.exceptions.ReviewAlreadyExistsException;
 import com.checkpoint.api.exceptions.ReviewNotFoundException;
 import com.checkpoint.api.mapper.ReviewMapper;
+import com.checkpoint.api.repositories.CommentRepository;
 import com.checkpoint.api.repositories.LikeRepository;
 import com.checkpoint.api.repositories.ReviewRepository;
 import com.checkpoint.api.repositories.UserGamePlayRepository;
@@ -44,6 +45,7 @@ public class ReviewServiceImpl implements ReviewService {
     private final UserRepository userRepository;
     private final UserGamePlayRepository userGamePlayRepository;
     private final LikeRepository likeRepository;
+    private final CommentRepository commentRepository;
     private final ReviewMapper reviewMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -55,6 +57,7 @@ public class ReviewServiceImpl implements ReviewService {
      * @param userRepository         the user repository
      * @param userGamePlayRepository the play log repository
      * @param likeRepository         the like repository
+     * @param commentRepository      the comment repository
      * @param reviewMapper           the review mapper
      * @param eventPublisher         the application event publisher
      */
@@ -63,6 +66,7 @@ public class ReviewServiceImpl implements ReviewService {
                              UserRepository userRepository,
                              UserGamePlayRepository userGamePlayRepository,
                              LikeRepository likeRepository,
+                             CommentRepository commentRepository,
                              ReviewMapper reviewMapper,
                              ApplicationEventPublisher eventPublisher) {
         this.reviewRepository = reviewRepository;
@@ -70,6 +74,7 @@ public class ReviewServiceImpl implements ReviewService {
         this.userRepository = userRepository;
         this.userGamePlayRepository = userGamePlayRepository;
         this.likeRepository = likeRepository;
+        this.commentRepository = commentRepository;
         this.reviewMapper = reviewMapper;
         this.eventPublisher = eventPublisher;
     }
@@ -96,7 +101,8 @@ public class ReviewServiceImpl implements ReviewService {
             long likesCount = likeRepository.countByReviewId(review.getId());
             boolean hasLiked = resolvedViewer != null
                     && likeRepository.existsByUserIdAndReviewId(resolvedViewer.getId(), review.getId());
-            return reviewMapper.toDto(review, likesCount, hasLiked);
+            long commentsCount = commentRepository.countByReviewId(review.getId());
+            return reviewMapper.toDto(review, likesCount, hasLiked, commentsCount);
         });
     }
 

--- a/api/src/test/java/com/checkpoint/api/controllers/CommentControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/CommentControllerTest.java
@@ -1,0 +1,322 @@
+package com.checkpoint.api.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.checkpoint.api.dto.social.CommentResponseDto;
+import com.checkpoint.api.dto.social.CommentUserDto;
+import com.checkpoint.api.exceptions.CommentNotFoundException;
+import com.checkpoint.api.exceptions.GameListNotFoundException;
+import com.checkpoint.api.exceptions.ReviewNotFoundException;
+import com.checkpoint.api.exceptions.UnauthorizedCommentAccessException;
+import com.checkpoint.api.security.ApiAuthenticationEntryPoint;
+import com.checkpoint.api.security.JwtAuthenticationFilter;
+import com.checkpoint.api.services.CommentService;
+
+/**
+ * Unit tests for {@link CommentController}.
+ */
+@WebMvcTest(CommentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CommentService commentService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private ApiAuthenticationEntryPoint apiAuthenticationEntryPoint;
+
+    private CommentResponseDto createTestComment() {
+        return new CommentResponseDto(
+                UUID.randomUUID(),
+                "Great review!",
+                new CommentUserDto(UUID.randomUUID(), "testuser", null),
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    @Nested
+    @DisplayName("GET /api/reviews/{reviewId}/comments")
+    class GetReviewComments {
+
+        @Test
+        @DisplayName("should return paginated comments for a review")
+        void getReviewComments_shouldReturnPaginatedComments() throws Exception {
+            // Given
+            UUID reviewId = UUID.randomUUID();
+            CommentResponseDto comment = createTestComment();
+            Page<CommentResponseDto> page = new PageImpl<>(List.of(comment), PageRequest.of(0, 20), 1);
+
+            when(commentService.getReviewComments(eq(reviewId), any())).thenReturn(page);
+
+            // When / Then
+            mockMvc.perform(get("/api/reviews/{reviewId}/comments", reviewId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].content").value("Great review!"))
+                    .andExpect(jsonPath("$.content[0].user.pseudo").value("testuser"))
+                    .andExpect(jsonPath("$.metadata.totalElements").value(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/reviews/{reviewId}/comments")
+    class AddReviewComment {
+
+        @Test
+        @DisplayName("should create comment and return 201")
+        @WithMockUser(username = "user@example.com")
+        void addReviewComment_shouldCreateComment() throws Exception {
+            // Given
+            UUID reviewId = UUID.randomUUID();
+            CommentResponseDto response = createTestComment();
+
+            when(commentService.addReviewComment(eq("user@example.com"), eq(reviewId), eq("Great review!")))
+                    .thenReturn(response);
+
+            // When / Then
+            mockMvc.perform(post("/api/reviews/{reviewId}/comments", reviewId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\": \"Great review!\"}"))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.content").value("Great review!"));
+        }
+
+        @Test
+        @DisplayName("should return 404 when review not found")
+        @WithMockUser(username = "user@example.com")
+        void addReviewComment_shouldReturn404WhenReviewNotFound() throws Exception {
+            // Given
+            UUID reviewId = UUID.randomUUID();
+
+            when(commentService.addReviewComment(eq("user@example.com"), eq(reviewId), eq("Nice!")))
+                    .thenThrow(new ReviewNotFoundException("Review not found with ID: " + reviewId));
+
+            // When / Then
+            mockMvc.perform(post("/api/reviews/{reviewId}/comments", reviewId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\": \"Nice!\"}"))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("should return 400 when content is blank")
+        @WithMockUser(username = "user@example.com")
+        void addReviewComment_shouldReturn400WhenContentBlank() throws Exception {
+            // Given
+            UUID reviewId = UUID.randomUUID();
+
+            // When / Then
+            mockMvc.perform(post("/api/reviews/{reviewId}/comments", reviewId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\": \"\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/lists/{listId}/comments")
+    class GetListComments {
+
+        @Test
+        @DisplayName("should return paginated comments for a list")
+        void getListComments_shouldReturnPaginatedComments() throws Exception {
+            // Given
+            UUID listId = UUID.randomUUID();
+            CommentResponseDto comment = createTestComment();
+            Page<CommentResponseDto> page = new PageImpl<>(List.of(comment), PageRequest.of(0, 20), 1);
+
+            when(commentService.getListComments(eq(listId), any())).thenReturn(page);
+
+            // When / Then
+            mockMvc.perform(get("/api/lists/{listId}/comments", listId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].content").value("Great review!"))
+                    .andExpect(jsonPath("$.metadata.totalElements").value(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/lists/{listId}/comments")
+    class AddListComment {
+
+        @Test
+        @DisplayName("should create comment and return 201")
+        @WithMockUser(username = "user@example.com")
+        void addListComment_shouldCreateComment() throws Exception {
+            // Given
+            UUID listId = UUID.randomUUID();
+            CommentResponseDto response = createTestComment();
+
+            when(commentService.addListComment(eq("user@example.com"), eq(listId), eq("Nice list!")))
+                    .thenReturn(response);
+
+            // When / Then
+            mockMvc.perform(post("/api/lists/{listId}/comments", listId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\": \"Nice list!\"}"))
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("should return 404 when list not found")
+        @WithMockUser(username = "user@example.com")
+        void addListComment_shouldReturn404WhenListNotFound() throws Exception {
+            // Given
+            UUID listId = UUID.randomUUID();
+
+            when(commentService.addListComment(eq("user@example.com"), eq(listId), eq("Hello")))
+                    .thenThrow(new GameListNotFoundException(listId));
+
+            // When / Then
+            mockMvc.perform(post("/api/lists/{listId}/comments", listId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\": \"Hello\"}"))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/comments/{commentId}")
+    class UpdateComment {
+
+        @Test
+        @DisplayName("should update comment and return 200")
+        @WithMockUser(username = "user@example.com")
+        void updateComment_shouldUpdateComment() throws Exception {
+            // Given
+            UUID commentId = UUID.randomUUID();
+            CommentResponseDto response = new CommentResponseDto(
+                    commentId, "Updated content",
+                    new CommentUserDto(UUID.randomUUID(), "testuser", null),
+                    LocalDateTime.now(), LocalDateTime.now()
+            );
+
+            when(commentService.updateComment(eq("user@example.com"), eq(commentId), eq("Updated content")))
+                    .thenReturn(response);
+
+            // When / Then
+            mockMvc.perform(put("/api/comments/{commentId}", commentId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\": \"Updated content\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content").value("Updated content"));
+        }
+
+        @Test
+        @DisplayName("should return 404 when comment not found")
+        @WithMockUser(username = "user@example.com")
+        void updateComment_shouldReturn404WhenNotFound() throws Exception {
+            // Given
+            UUID commentId = UUID.randomUUID();
+
+            when(commentService.updateComment(eq("user@example.com"), eq(commentId), eq("Updated")))
+                    .thenThrow(new CommentNotFoundException(commentId));
+
+            // When / Then
+            mockMvc.perform(put("/api/comments/{commentId}", commentId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\": \"Updated\"}"))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("should return 403 when not comment owner")
+        @WithMockUser(username = "user@example.com")
+        void updateComment_shouldReturn403WhenNotOwner() throws Exception {
+            // Given
+            UUID commentId = UUID.randomUUID();
+
+            when(commentService.updateComment(eq("user@example.com"), eq(commentId), eq("Hacked")))
+                    .thenThrow(new UnauthorizedCommentAccessException(commentId));
+
+            // When / Then
+            mockMvc.perform(put("/api/comments/{commentId}", commentId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\": \"Hacked\"}"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/comments/{commentId}")
+    class DeleteComment {
+
+        @Test
+        @DisplayName("should delete comment and return 204")
+        @WithMockUser(username = "user@example.com")
+        void deleteComment_shouldDeleteComment() throws Exception {
+            // Given
+            UUID commentId = UUID.randomUUID();
+
+            doNothing().when(commentService).deleteComment("user@example.com", commentId);
+
+            // When / Then
+            mockMvc.perform(delete("/api/comments/{commentId}", commentId))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("should return 404 when comment not found")
+        @WithMockUser(username = "user@example.com")
+        void deleteComment_shouldReturn404WhenNotFound() throws Exception {
+            // Given
+            UUID commentId = UUID.randomUUID();
+
+            doThrow(new CommentNotFoundException(commentId))
+                    .when(commentService).deleteComment("user@example.com", commentId);
+
+            // When / Then
+            mockMvc.perform(delete("/api/comments/{commentId}", commentId))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("should return 403 when not comment owner")
+        @WithMockUser(username = "user@example.com")
+        void deleteComment_shouldReturn403WhenNotOwner() throws Exception {
+            // Given
+            UUID commentId = UUID.randomUUID();
+
+            doThrow(new UnauthorizedCommentAccessException(commentId))
+                    .when(commentService).deleteComment("user@example.com", commentId);
+
+            // When / Then
+            mockMvc.perform(delete("/api/comments/{commentId}", commentId))
+                    .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/controllers/GameListControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/GameListControllerTest.java
@@ -59,7 +59,7 @@ class GameListControllerTest {
             // Given
             GameListCardDto card = new GameListCardDto(
                     UUID.randomUUID(), "Top RPGs", "Best RPGs of all time", false,
-                    10, 42L, "gamer123", null,
+                    10, 42L, 0L, "gamer123", null,
                     List.of("cover1.jpg", "cover2.jpg"), LocalDateTime.now());
             Page<GameListCardDto> page = new PageImpl<>(List.of(card), PageRequest.of(0, 20), 1);
 
@@ -85,7 +85,7 @@ class GameListControllerTest {
             // Given
             GameListCardDto card = new GameListCardDto(
                     UUID.randomUUID(), "Most Liked", null, false,
-                    5, 100L, "curator", null, List.of(), LocalDateTime.now());
+                    5, 100L, 0L, "curator", null, List.of(), LocalDateTime.now());
             Page<GameListCardDto> page = new PageImpl<>(List.of(card), PageRequest.of(0, 20), 1);
 
             when(gameListService.getPopularPublicLists(any())).thenReturn(page);
@@ -109,7 +109,7 @@ class GameListControllerTest {
             UUID listId = UUID.randomUUID();
             GameListDetailDto detail = new GameListDetailDto(
                     listId, "Top RPGs", "My favorite RPGs", false,
-                    2, 5L, "gamer123", null,
+                    2, 5L, 0L, "gamer123", null,
                     List.of(), false, false,
                     LocalDateTime.now(), LocalDateTime.now());
 
@@ -131,7 +131,7 @@ class GameListControllerTest {
             UUID listId = UUID.randomUUID();
             GameListDetailDto detail = new GameListDetailDto(
                     listId, "My List", null, false,
-                    1, 0L, "testuser", null,
+                    1, 0L, 0L, "testuser", null,
                     List.of(), true, false,
                     LocalDateTime.now(), LocalDateTime.now());
 

--- a/api/src/test/java/com/checkpoint/api/controllers/PlayLogReviewControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/PlayLogReviewControllerTest.java
@@ -79,7 +79,8 @@ class PlayLogReviewControllerTest {
                 PlayStatus.COMPLETED,
                 false,
                 0,
-                false
+                false,
+                0
         );
     }
 
@@ -162,7 +163,8 @@ class PlayLogReviewControllerTest {
                     PlayStatus.COMPLETED,
                     false,
                     0,
-                    false
+                    false,
+                    0
             );
             when(reviewService.updatePlayLogReview(eq("user@example.com"), eq(playId), any(ReviewRequestDto.class)))
                     .thenReturn(updatedResponse);

--- a/api/src/test/java/com/checkpoint/api/controllers/ProfileControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/ProfileControllerTest.java
@@ -137,7 +137,7 @@ class ProfileControllerTest {
                     UUID.randomUUID(), "Great game!", false,
                     LocalDateTime.now(), LocalDateTime.now(),
                     new ReviewUserDto(UUID.randomUUID(), "testuser", null),
-                    null, null, null, null, 0, false
+                    null, null, null, null, 0, false, 0
             );
             Page<ReviewResponseDto> page = new PageImpl<>(List.of(review));
 

--- a/api/src/test/java/com/checkpoint/api/controllers/ReviewControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/ReviewControllerTest.java
@@ -67,7 +67,8 @@ class ReviewControllerTest {
                 PlayStatus.COMPLETED,
                 false,
                 0,
-                false
+                false,
+                0
         );
     }
 

--- a/api/src/test/java/com/checkpoint/api/controllers/UserGameListControllerTest.java
+++ b/api/src/test/java/com/checkpoint/api/controllers/UserGameListControllerTest.java
@@ -68,7 +68,7 @@ class UserGameListControllerTest {
             UUID listId = UUID.randomUUID();
             GameListDetailDto response = new GameListDetailDto(
                     listId, "My Favorites", "Best games ever", false,
-                    0, 0L, "testuser", null,
+                    0, 0L, 0L, "testuser", null,
                     List.of(), true, false,
                     LocalDateTime.now(), LocalDateTime.now());
 
@@ -119,7 +119,7 @@ class UserGameListControllerTest {
             // Given
             GameListCardDto card = new GameListCardDto(
                     UUID.randomUUID(), "My List", null, false,
-                    5, 3L, "testuser", null, List.of(), LocalDateTime.now());
+                    5, 3L, 0L, "testuser", null, List.of(), LocalDateTime.now());
             Page<GameListCardDto> page = new PageImpl<>(List.of(card), PageRequest.of(0, 20), 1);
 
             when(gameListService.getUserLists(eq("user@example.com"), any()))
@@ -145,7 +145,7 @@ class UserGameListControllerTest {
             UUID listId = UUID.randomUUID();
             GameListDetailDto response = new GameListDetailDto(
                     listId, "Updated Title", null, false,
-                    0, 0L, "testuser", null,
+                    0, 0L, 0L, "testuser", null,
                     List.of(), true, false,
                     LocalDateTime.now(), LocalDateTime.now());
 
@@ -230,7 +230,7 @@ class UserGameListControllerTest {
             UUID videoGameId = UUID.randomUUID();
             GameListDetailDto response = new GameListDetailDto(
                     listId, "My List", null, false,
-                    1, 0L, "testuser", null,
+                    1, 0L, 0L, "testuser", null,
                     List.of(), true, false,
                     LocalDateTime.now(), LocalDateTime.now());
 
@@ -320,7 +320,7 @@ class UserGameListControllerTest {
             UUID game2 = UUID.randomUUID();
             GameListDetailDto response = new GameListDetailDto(
                     listId, "My List", null, false,
-                    2, 0L, "testuser", null,
+                    2, 0L, 0L, "testuser", null,
                     List.of(), true, false,
                     LocalDateTime.now(), LocalDateTime.now());
 

--- a/api/src/test/java/com/checkpoint/api/services/ReviewServiceImplTest.java
+++ b/api/src/test/java/com/checkpoint/api/services/ReviewServiceImplTest.java
@@ -40,6 +40,7 @@ import com.checkpoint.api.exceptions.ReviewAlreadyExistsException;
 import com.checkpoint.api.exceptions.ReviewNotFoundException;
 import com.checkpoint.api.events.ReviewCreatedEvent;
 import com.checkpoint.api.mapper.ReviewMapper;
+import com.checkpoint.api.repositories.CommentRepository;
 import com.checkpoint.api.repositories.LikeRepository;
 import com.checkpoint.api.repositories.ReviewRepository;
 import com.checkpoint.api.repositories.UserGamePlayRepository;
@@ -69,6 +70,9 @@ class ReviewServiceImplTest {
     private LikeRepository likeRepository;
 
     @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
     private ReviewMapper reviewMapper;
 
     @Mock
@@ -87,7 +91,7 @@ class ReviewServiceImplTest {
     void setUp() {
         reviewService = new ReviewServiceImpl(
                 reviewRepository, videoGameRepository, userRepository,
-                userGamePlayRepository, likeRepository, reviewMapper, eventPublisher);
+                userGamePlayRepository, likeRepository, commentRepository, reviewMapper, eventPublisher);
 
         gameId = UUID.randomUUID();
         playId = UUID.randomUUID();
@@ -124,13 +128,14 @@ class ReviewServiceImplTest {
             when(videoGameRepository.existsById(gameId)).thenReturn(true);
             when(reviewRepository.findByVideoGameId(gameId, pageable)).thenReturn(reviewPage);
             when(likeRepository.countByReviewId(any())).thenReturn(0L);
+            when(commentRepository.countByReviewId(any())).thenReturn(0L);
 
             ReviewResponseDto responseDto = new ReviewResponseDto(
                     UUID.randomUUID(), "Good", false,
                     LocalDateTime.now(), LocalDateTime.now(),
                     new ReviewUserDto(testUser.getId(), testUser.getPseudo(), null),
-                    playId, "PC", PlayStatus.COMPLETED, false, 0, false);
-            when(reviewMapper.toDto(review, 0L, false)).thenReturn(responseDto);
+                    playId, "PC", PlayStatus.COMPLETED, false, 0, false, 0);
+            when(reviewMapper.toDto(review, 0L, false, 0L)).thenReturn(responseDto);
 
             // When
             Page<ReviewResponseDto> result = reviewService.getGameReviews(gameId, null, pageable);
@@ -175,7 +180,7 @@ class ReviewServiceImplTest {
                     savedReview.getId(), "Great game!", false,
                     LocalDateTime.now(), LocalDateTime.now(),
                     new ReviewUserDto(testUser.getId(), testUser.getPseudo(), null),
-                    playId, "PC", PlayStatus.COMPLETED, false, 0, false);
+                    playId, "PC", PlayStatus.COMPLETED, false, 0, false, 0);
             when(reviewMapper.toDto(savedReview)).thenReturn(responseDto);
 
             // When
@@ -259,7 +264,7 @@ class ReviewServiceImplTest {
                     existingReview.getId(), "Updated review", true,
                     LocalDateTime.now(), LocalDateTime.now(),
                     new ReviewUserDto(testUser.getId(), testUser.getPseudo(), null),
-                    playId, "PC", PlayStatus.COMPLETED, false, 0, false);
+                    playId, "PC", PlayStatus.COMPLETED, false, 0, false, 0);
             when(reviewMapper.toDto(existingReview)).thenReturn(responseDto);
 
             // When
@@ -346,7 +351,7 @@ class ReviewServiceImplTest {
                     review.getId(), "Great game!", false,
                     LocalDateTime.now(), LocalDateTime.now(),
                     new ReviewUserDto(testUser.getId(), testUser.getPseudo(), null),
-                    playId, "PC", PlayStatus.COMPLETED, false, 0, false);
+                    playId, "PC", PlayStatus.COMPLETED, false, 0, false, 0);
             when(reviewMapper.toDto(review)).thenReturn(responseDto);
 
             // When

--- a/api/src/test/java/com/checkpoint/api/services/impl/CommentServiceImplTest.java
+++ b/api/src/test/java/com/checkpoint/api/services/impl/CommentServiceImplTest.java
@@ -1,0 +1,304 @@
+package com.checkpoint.api.services.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.checkpoint.api.dto.social.CommentResponseDto;
+import com.checkpoint.api.dto.social.CommentUserDto;
+import com.checkpoint.api.entities.Comment;
+import com.checkpoint.api.entities.GameList;
+import com.checkpoint.api.entities.Review;
+import com.checkpoint.api.entities.User;
+import com.checkpoint.api.exceptions.CommentNotFoundException;
+import com.checkpoint.api.exceptions.GameListNotFoundException;
+import com.checkpoint.api.exceptions.ReviewNotFoundException;
+import com.checkpoint.api.exceptions.UnauthorizedCommentAccessException;
+import com.checkpoint.api.mapper.CommentMapper;
+import com.checkpoint.api.repositories.CommentRepository;
+import com.checkpoint.api.repositories.GameListRepository;
+import com.checkpoint.api.repositories.ReviewRepository;
+import com.checkpoint.api.repositories.UserRepository;
+
+/**
+ * Unit tests for {@link CommentServiceImpl}.
+ */
+@ExtendWith(MockitoExtension.class)
+class CommentServiceImplTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private GameListRepository gameListRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CommentMapper commentMapper;
+
+    private CommentServiceImpl commentService;
+
+    private User testUser;
+    private User otherUser;
+    private Review testReview;
+    private GameList testList;
+
+    @BeforeEach
+    void setUp() {
+        commentService = new CommentServiceImpl(
+                commentRepository, reviewRepository, gameListRepository,
+                userRepository, commentMapper);
+
+        testUser = new User();
+        testUser.setId(UUID.randomUUID());
+        testUser.setPseudo("testuser");
+        testUser.setEmail("test@test.com");
+
+        otherUser = new User();
+        otherUser.setId(UUID.randomUUID());
+        otherUser.setPseudo("otheruser");
+        otherUser.setEmail("other@test.com");
+
+        testReview = new Review();
+        testReview.setId(UUID.randomUUID());
+
+        testList = new GameList("Test List", testUser);
+        testList.setId(UUID.randomUUID());
+    }
+
+    @Nested
+    @DisplayName("addReviewComment()")
+    class AddReviewComment {
+
+        @Test
+        @DisplayName("should create a comment on a review")
+        void addReviewComment_shouldCreateComment() {
+            // Given
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(reviewRepository.findById(testReview.getId())).thenReturn(Optional.of(testReview));
+
+            Comment savedComment = Comment.onReview("Nice!", testUser, testReview);
+            savedComment.setId(UUID.randomUUID());
+            when(commentRepository.save(any(Comment.class))).thenReturn(savedComment);
+
+            CommentResponseDto expectedDto = new CommentResponseDto(
+                    savedComment.getId(), "Nice!",
+                    new CommentUserDto(testUser.getId(), testUser.getPseudo(), null),
+                    null, null);
+            when(commentMapper.toDto(savedComment)).thenReturn(expectedDto);
+
+            // When
+            CommentResponseDto result = commentService.addReviewComment("test@test.com", testReview.getId(), "Nice!");
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.content()).isEqualTo("Nice!");
+            verify(commentRepository).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("should throw ReviewNotFoundException when review does not exist")
+        void addReviewComment_shouldThrowWhenReviewNotFound() {
+            // Given
+            UUID reviewId = UUID.randomUUID();
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(reviewRepository.findById(reviewId)).thenReturn(Optional.empty());
+
+            // When / Then
+            assertThatThrownBy(() -> commentService.addReviewComment("test@test.com", reviewId, "Nice!"))
+                    .isInstanceOf(ReviewNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("addListComment()")
+    class AddListComment {
+
+        @Test
+        @DisplayName("should create a comment on a list")
+        void addListComment_shouldCreateComment() {
+            // Given
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(gameListRepository.findById(testList.getId())).thenReturn(Optional.of(testList));
+
+            Comment savedComment = Comment.onList("Cool list!", testUser, testList);
+            savedComment.setId(UUID.randomUUID());
+            when(commentRepository.save(any(Comment.class))).thenReturn(savedComment);
+
+            CommentResponseDto expectedDto = new CommentResponseDto(
+                    savedComment.getId(), "Cool list!",
+                    new CommentUserDto(testUser.getId(), testUser.getPseudo(), null),
+                    null, null);
+            when(commentMapper.toDto(savedComment)).thenReturn(expectedDto);
+
+            // When
+            CommentResponseDto result = commentService.addListComment("test@test.com", testList.getId(), "Cool list!");
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.content()).isEqualTo("Cool list!");
+            verify(commentRepository).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("should throw GameListNotFoundException when list does not exist")
+        void addListComment_shouldThrowWhenListNotFound() {
+            // Given
+            UUID listId = UUID.randomUUID();
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(gameListRepository.findById(listId)).thenReturn(Optional.empty());
+
+            // When / Then
+            assertThatThrownBy(() -> commentService.addListComment("test@test.com", listId, "Nice!"))
+                    .isInstanceOf(GameListNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getReviewComments()")
+    class GetReviewComments {
+
+        @Test
+        @DisplayName("should return paginated comments for a review")
+        void getReviewComments_shouldReturnPaginatedComments() {
+            // Given
+            Pageable pageable = PageRequest.of(0, 10);
+            Comment comment = Comment.onReview("Great!", testUser, testReview);
+            comment.setId(UUID.randomUUID());
+            Page<Comment> commentPage = new PageImpl<>(List.of(comment));
+
+            when(commentRepository.findByReviewId(testReview.getId(), pageable)).thenReturn(commentPage);
+
+            CommentResponseDto dto = new CommentResponseDto(
+                    comment.getId(), "Great!",
+                    new CommentUserDto(testUser.getId(), testUser.getPseudo(), null),
+                    null, null);
+            when(commentMapper.toDto(comment)).thenReturn(dto);
+
+            // When
+            Page<CommentResponseDto> result = commentService.getReviewComments(testReview.getId(), pageable);
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).content()).isEqualTo("Great!");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateComment()")
+    class UpdateComment {
+
+        @Test
+        @DisplayName("should update comment when user is owner")
+        void updateComment_shouldUpdateWhenOwner() {
+            // Given
+            Comment comment = Comment.onReview("Old content", testUser, testReview);
+            comment.setId(UUID.randomUUID());
+
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
+            when(commentRepository.save(comment)).thenReturn(comment);
+
+            CommentResponseDto expectedDto = new CommentResponseDto(
+                    comment.getId(), "New content",
+                    new CommentUserDto(testUser.getId(), testUser.getPseudo(), null),
+                    null, null);
+            when(commentMapper.toDto(comment)).thenReturn(expectedDto);
+
+            // When
+            CommentResponseDto result = commentService.updateComment("test@test.com", comment.getId(), "New content");
+
+            // Then
+            assertThat(result.content()).isEqualTo("New content");
+            verify(commentRepository).save(comment);
+        }
+
+        @Test
+        @DisplayName("should throw UnauthorizedCommentAccessException when user is not owner")
+        void updateComment_shouldThrowWhenNotOwner() {
+            // Given
+            Comment comment = Comment.onReview("Content", otherUser, testReview);
+            comment.setId(UUID.randomUUID());
+
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
+
+            // When / Then
+            assertThatThrownBy(() -> commentService.updateComment("test@test.com", comment.getId(), "Hacked"))
+                    .isInstanceOf(UnauthorizedCommentAccessException.class);
+        }
+
+        @Test
+        @DisplayName("should throw CommentNotFoundException when comment does not exist")
+        void updateComment_shouldThrowWhenNotFound() {
+            // Given
+            UUID commentId = UUID.randomUUID();
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+            // When / Then
+            assertThatThrownBy(() -> commentService.updateComment("test@test.com", commentId, "Updated"))
+                    .isInstanceOf(CommentNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteComment()")
+    class DeleteComment {
+
+        @Test
+        @DisplayName("should delete comment when user is owner")
+        void deleteComment_shouldDeleteWhenOwner() {
+            // Given
+            Comment comment = Comment.onReview("Content", testUser, testReview);
+            comment.setId(UUID.randomUUID());
+
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
+
+            // When
+            commentService.deleteComment("test@test.com", comment.getId());
+
+            // Then
+            verify(commentRepository).delete(comment);
+        }
+
+        @Test
+        @DisplayName("should throw UnauthorizedCommentAccessException when user is not owner")
+        void deleteComment_shouldThrowWhenNotOwner() {
+            // Given
+            Comment comment = Comment.onReview("Content", otherUser, testReview);
+            comment.setId(UUID.randomUUID());
+
+            when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(testUser));
+            when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
+
+            // When / Then
+            assertThatThrownBy(() -> commentService.deleteComment("test@test.com", comment.getId()))
+                    .isInstanceOf(UnauthorizedCommentAccessException.class);
+        }
+    }
+}

--- a/api/src/test/java/com/checkpoint/api/services/impl/GameListServiceImplTest.java
+++ b/api/src/test/java/com/checkpoint/api/services/impl/GameListServiceImplTest.java
@@ -45,6 +45,7 @@ import com.checkpoint.api.exceptions.GameListNotFoundException;
 import com.checkpoint.api.exceptions.GameNotInListException;
 import com.checkpoint.api.exceptions.UnauthorizedListAccessException;
 import com.checkpoint.api.mapper.GameListMapper;
+import com.checkpoint.api.repositories.CommentRepository;
 import com.checkpoint.api.repositories.GameListEntryRepository;
 import com.checkpoint.api.repositories.GameListRepository;
 import com.checkpoint.api.repositories.LikeRepository;
@@ -70,6 +71,9 @@ class GameListServiceImplTest {
     private LikeRepository likeRepository;
 
     @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
     private GameListMapper gameListMapper;
 
     private GameListServiceImpl service;
@@ -85,7 +89,7 @@ class GameListServiceImplTest {
         service = new GameListServiceImpl(
                 gameListRepository, gameListEntryRepository,
                 userRepository, videoGameRepository,
-                likeRepository, gameListMapper);
+                likeRepository, commentRepository, gameListMapper);
 
         testUser = new User("testuser", "user@example.com", "password");
         testUser.setId(UUID.randomUUID());
@@ -105,7 +109,7 @@ class GameListServiceImplTest {
 
         testDetailDto = new GameListDetailDto(
                 testList.getId(), testList.getTitle(), null, false,
-                0, 0L, testUser.getPseudo(), null,
+                0, 0L, 0L, testUser.getPseudo(), null,
                 List.of(), true, false,
                 testList.getCreatedAt(), testList.getUpdatedAt());
     }
@@ -121,7 +125,7 @@ class GameListServiceImplTest {
             CreateGameListRequestDto request = new CreateGameListRequestDto("My List", "A description", false);
             when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(testUser));
             when(gameListRepository.save(any(GameList.class))).thenReturn(testList);
-            when(gameListMapper.toDetailDto(any(GameList.class), eq(List.of()), eq(0L), eq(true), eq(false)))
+            when(gameListMapper.toDetailDto(any(GameList.class), eq(List.of()), eq(0L), eq(0L), eq(true), eq(false)))
                     .thenReturn(testDetailDto);
 
             // When
@@ -139,7 +143,7 @@ class GameListServiceImplTest {
             CreateGameListRequestDto request = new CreateGameListRequestDto("My List", null, null);
             when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(testUser));
             when(gameListRepository.save(any(GameList.class))).thenReturn(testList);
-            when(gameListMapper.toDetailDto(any(GameList.class), anyList(), anyLong(), anyBoolean(), anyBoolean()))
+            when(gameListMapper.toDetailDto(any(GameList.class), anyList(), anyLong(), anyLong(), anyBoolean(), anyBoolean()))
                     .thenReturn(testDetailDto);
 
             // When
@@ -164,7 +168,7 @@ class GameListServiceImplTest {
             when(gameListRepository.save(any(GameList.class))).thenReturn(testList);
             when(gameListEntryRepository.findByGameListIdOrderByPositionAsc(testList.getId())).thenReturn(List.of());
             when(likeRepository.countByGameListId(testList.getId())).thenReturn(0L);
-            when(gameListMapper.toDetailDto(any(GameList.class), anyList(), anyLong(), anyBoolean(), anyBoolean()))
+            when(gameListMapper.toDetailDto(any(GameList.class), anyList(), anyLong(), anyLong(), anyBoolean(), anyBoolean()))
                     .thenReturn(testDetailDto);
 
             // When
@@ -253,7 +257,7 @@ class GameListServiceImplTest {
             when(gameListEntryRepository.save(any(GameListEntry.class))).thenAnswer(inv -> inv.getArgument(0));
             when(gameListEntryRepository.findByGameListIdOrderByPositionAsc(testList.getId())).thenReturn(List.of());
             when(likeRepository.countByGameListId(testList.getId())).thenReturn(0L);
-            when(gameListMapper.toDetailDto(any(GameList.class), anyList(), anyLong(), anyBoolean(), anyBoolean()))
+            when(gameListMapper.toDetailDto(any(GameList.class), anyList(), anyLong(), anyLong(), anyBoolean(), anyBoolean()))
                     .thenReturn(testDetailDto);
 
             // When
@@ -344,7 +348,7 @@ class GameListServiceImplTest {
                     .thenReturn(Optional.of(entry1));
             when(gameListEntryRepository.findByGameListIdOrderByPositionAsc(testList.getId())).thenReturn(List.of());
             when(likeRepository.countByGameListId(testList.getId())).thenReturn(0L);
-            when(gameListMapper.toDetailDto(any(GameList.class), anyList(), anyLong(), anyBoolean(), anyBoolean()))
+            when(gameListMapper.toDetailDto(any(GameList.class), anyList(), anyLong(), anyLong(), anyBoolean(), anyBoolean()))
                     .thenReturn(testDetailDto);
 
             // When
@@ -383,7 +387,7 @@ class GameListServiceImplTest {
             when(gameListRepository.findById(testList.getId())).thenReturn(Optional.of(testList));
             when(gameListEntryRepository.findByGameListIdOrderByPositionAsc(testList.getId())).thenReturn(List.of());
             when(likeRepository.countByGameListId(testList.getId())).thenReturn(5L);
-            when(gameListMapper.toDetailDto(testList, List.of(), 5L, false, false)).thenReturn(testDetailDto);
+            when(gameListMapper.toDetailDto(testList, List.of(), 5L, 0L, false, false)).thenReturn(testDetailDto);
 
             // When
             GameListDetailDto result = service.getListDetail(testList.getId(), null);
@@ -414,7 +418,7 @@ class GameListServiceImplTest {
             when(likeRepository.existsByUserIdAndGameListId(testUser.getId(), testList.getId())).thenReturn(false);
             when(gameListEntryRepository.findByGameListIdOrderByPositionAsc(testList.getId())).thenReturn(List.of());
             when(likeRepository.countByGameListId(testList.getId())).thenReturn(0L);
-            when(gameListMapper.toDetailDto(testList, List.of(), 0L, true, false)).thenReturn(testDetailDto);
+            when(gameListMapper.toDetailDto(testList, List.of(), 0L, 0L, true, false)).thenReturn(testDetailDto);
 
             // When
             GameListDetailDto result = service.getListDetail(testList.getId(), "user@example.com");
@@ -450,12 +454,12 @@ class GameListServiceImplTest {
             Page<GameList> page = new PageImpl<>(List.of(testList), pageable, 1);
             GameListCardDto cardDto = new GameListCardDto(
                     testList.getId(), testList.getTitle(), null, false,
-                    0, 0L, testUser.getPseudo(), null, List.of(), testList.getCreatedAt());
+                    0, 0L, 0L, testUser.getPseudo(), null, List.of(), testList.getCreatedAt());
 
             when(gameListRepository.findAllPublic(pageable)).thenReturn(page);
             when(likeRepository.countByGameListId(testList.getId())).thenReturn(0L);
             when(gameListEntryRepository.findByGameListIdOrderByPositionAsc(testList.getId())).thenReturn(List.of());
-            when(gameListMapper.toCardDto(testList, 0L, List.of())).thenReturn(cardDto);
+            when(gameListMapper.toCardDto(testList, 0L, 0L, List.of())).thenReturn(cardDto);
 
             // When
             Page<GameListCardDto> result = service.getRecentPublicLists(pageable);

--- a/web/src/components/comments/comment-section.tsx
+++ b/web/src/components/comments/comment-section.tsx
@@ -1,0 +1,311 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { MessageSquare, MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import type { Comment, CommentsResponse } from '@/types/comment'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Textarea } from '@/components/ui/textarea'
+import { useAuth } from '@/hooks/use-auth'
+import {
+  deleteComment,
+  listCommentsQueryOptions,
+  postListComment,
+  postReviewComment,
+  reviewCommentsQueryOptions,
+  updateComment,
+} from '@/queries/comment'
+
+interface CommentSectionProps {
+  targetType: 'review' | 'list'
+  targetId: string
+}
+
+export function CommentSection({ targetType, targetId }: CommentSectionProps) {
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+  const [page, setPage] = useState(0)
+  const [newComment, setNewComment] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editContent, setEditContent] = useState('')
+  const size = 10
+
+  const queryOptions =
+    targetType === 'review'
+      ? reviewCommentsQueryOptions(targetId, page, size)
+      : listCommentsQueryOptions(targetId, page, size)
+
+  const { data, isLoading } = useQuery(queryOptions)
+
+  const invalidateComments = () => {
+    void queryClient.invalidateQueries({
+      queryKey:
+        targetType === 'review'
+          ? ['reviews', targetId, 'comments']
+          : ['lists', targetId, 'comments'],
+    })
+  }
+
+  const postMutation = useMutation({
+    mutationFn: (content: string) =>
+      targetType === 'review'
+        ? postReviewComment(targetId, content)
+        : postListComment(targetId, content),
+    onSuccess: () => {
+      setNewComment('')
+      invalidateComments()
+    },
+    onError: () => {
+      toast.error('Failed to post comment')
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({ commentId, content }: { commentId: string; content: string }) =>
+      updateComment(commentId, content),
+    onSuccess: () => {
+      setEditingId(null)
+      setEditContent('')
+      invalidateComments()
+    },
+    onError: () => {
+      toast.error('Failed to update comment')
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (commentId: string) => deleteComment(commentId),
+    onMutate: async (commentId) => {
+      const queryKey = queryOptions.queryKey
+      await queryClient.cancelQueries({ queryKey })
+      const previous = queryClient.getQueryData<CommentsResponse>(queryKey)
+      queryClient.setQueryData<CommentsResponse>(queryKey, (old) => {
+        if (!old) return old
+        return {
+          ...old,
+          content: old.content.filter((c) => c.id !== commentId),
+          metadata: {
+            ...old.metadata,
+            totalElements: old.metadata.totalElements - 1,
+          },
+        }
+      })
+      return { previous }
+    },
+    onError: (_err, _commentId, context) => {
+      toast.error('Failed to delete comment')
+      if (context?.previous) {
+        queryClient.setQueryData(queryOptions.queryKey, context.previous)
+      }
+    },
+    onSettled: () => {
+      invalidateComments()
+    },
+  })
+
+  const startEdit = (comment: Comment) => {
+    setEditingId(comment.id)
+    setEditContent(comment.content)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditContent('')
+  }
+
+  const handleSubmitNew = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!newComment.trim()) return
+    postMutation.mutate(newComment.trim())
+  }
+
+  const handleSubmitEdit = (e: React.FormEvent, commentId: string) => {
+    e.preventDefault()
+    if (!editContent.trim()) return
+    updateMutation.mutate({ commentId, content: editContent.trim() })
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="flex items-center gap-2 text-lg font-semibold">
+        <MessageSquare className="size-5" />
+        Comments
+        {data && data.metadata.totalElements > 0 && (
+          <span className="text-sm font-normal text-muted-foreground">
+            ({data.metadata.totalElements})
+          </span>
+        )}
+      </h3>
+
+      {/* New comment form */}
+      {user ? (
+        <form onSubmit={handleSubmitNew} className="space-y-3">
+          <div className="flex gap-3">
+            <Avatar className="mt-1 size-8 shrink-0">
+              <AvatarImage src="/images/default-user.jpg" alt={user.username} />
+              <AvatarFallback className="text-xs">
+                {user.username.substring(0, 2).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex-1 space-y-2">
+              <Textarea
+                placeholder="Write a comment..."
+                className="min-h-[80px] resize-y"
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+              />
+              <div className="flex justify-end">
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={!newComment.trim() || postMutation.isPending}
+                >
+                  {postMutation.isPending ? 'Posting...' : 'Post Comment'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </form>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Log in to leave a comment.
+        </p>
+      )}
+
+      {/* Comments list */}
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading comments...</p>
+      ) : data && data.content.length > 0 ? (
+        <div className="space-y-4">
+          {data.content.map((comment) => (
+            <div key={comment.id} className="flex gap-3">
+              <Avatar className="mt-1 size-8 shrink-0">
+                <AvatarImage
+                  src={comment.user.picture ?? undefined}
+                  alt={comment.user.pseudo}
+                />
+                <AvatarFallback className="text-xs">
+                  {comment.user.pseudo.substring(0, 2).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">
+                    {comment.user.pseudo}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(comment.createdAt).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </span>
+                  {comment.createdAt !== comment.updatedAt && (
+                    <span className="text-xs text-muted-foreground">(edited)</span>
+                  )}
+                  {user && user.id === comment.user.id && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="ml-auto h-7 w-7"
+                        >
+                          <MoreHorizontal className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => startEdit(comment)}>
+                          <Pencil className="mr-2 size-4" />
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="text-destructive"
+                          onClick={() => deleteMutation.mutate(comment.id)}
+                        >
+                          <Trash2 className="mr-2 size-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </div>
+                {editingId === comment.id ? (
+                  <form
+                    onSubmit={(e) => handleSubmitEdit(e, comment.id)}
+                    className="mt-2 space-y-2"
+                  >
+                    <Textarea
+                      className="min-h-[60px] resize-y"
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                    />
+                    <div className="flex gap-2">
+                      <Button
+                        type="submit"
+                        size="sm"
+                        disabled={
+                          !editContent.trim() || updateMutation.isPending
+                        }
+                      >
+                        {updateMutation.isPending ? 'Saving...' : 'Save'}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={cancelEdit}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </form>
+                ) : (
+                  <p className="mt-1 text-sm leading-relaxed whitespace-pre-line">
+                    {comment.content}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+
+          {/* Pagination */}
+          {data.metadata.totalPages > 1 && (
+            <div className="flex items-center justify-center gap-4 pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.metadata.hasPrevious}
+                onClick={() => setPage((old) => Math.max(old - 1, 0))}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {data.metadata.page + 1} of {data.metadata.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.metadata.hasNext}
+                onClick={() => setPage((old) => old + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No comments yet. Be the first to comment!
+        </p>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useHotkey } from '@tanstack/react-hotkeys'
 import { Command, Plus, Search, User } from 'lucide-react'
@@ -9,8 +9,11 @@ import { AvatarDropdown } from './avatar-dropdown'
 import { useAuth } from '@/hooks/use-auth'
 
 function useIsMac() {
-  if (typeof navigator === 'undefined') return true
-  return /Mac|iPod|iPhone|iPad/.test(navigator.userAgent)
+  const [isMac, setIsMac] = useState<boolean | null>(null)
+  useEffect(() => {
+    setIsMac(/Mac|iPod|iPhone|iPad/.test(navigator.userAgent))
+  }, [])
+  return isMac
 }
 
 export const Header = () => {
@@ -61,10 +64,12 @@ export const Header = () => {
         >
           <Search className="size-4 shrink-0" />
           <span>Search...</span>
-          <kbd className="pointer-events-none hidden select-none items-center gap-0.5 rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground sm:inline-flex">
-            {isMac ? <Command className="size-2.5" /> : <span>Ctrl+</span>}
-            <span>K</span>
-          </kbd>
+          {isMac !== null && (
+            <kbd className="pointer-events-none hidden select-none items-center gap-0.5 rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground sm:inline-flex">
+              {isMac ? <Command className="size-2.5" /> : <span>Ctrl+</span>}
+              <span>K</span>
+            </kbd>
+          )}
         </button>
         <SearchCommand open={searchOpen} onOpenChange={setSearchOpen} />
         {user && (

--- a/web/src/components/reviews/review-list.tsx
+++ b/web/src/components/reviews/review-list.tsx
@@ -1,10 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Flag, Gamepad2, RefreshCw } from 'lucide-react'
+import { Flag, Gamepad2, MessageSquare, RefreshCw } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
 import type { PlayStatus } from '@/types/interaction'
 import type { ReviewsResponse } from '@/types/review'
+import { CommentSection } from '@/components/comments/comment-section'
 import { ReportReviewDialog } from '@/components/reviews/report-review-dialog'
 import { LikeButton } from '@/components/shared/like-button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -51,6 +52,9 @@ export function ReviewList({ gameId }: ReviewListProps) {
   const [reportingReviewId, setReportingReviewId] = useState<string | null>(
     null,
   )
+  const [expandedComments, setExpandedComments] = useState<
+    Record<string, boolean>
+  >({})
   const size = 10
 
   const queryClient = useQueryClient()
@@ -198,6 +202,20 @@ export function ReviewList({ gameId }: ReviewListProps) {
                     disabled={!user}
                     isPending={likeMutation.isPending}
                   />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1"
+                    onClick={() =>
+                      setExpandedComments((prev) => ({
+                        ...prev,
+                        [review.id]: !prev[review.id],
+                      }))
+                    }
+                  >
+                    <MessageSquare className="size-4" />
+                    {review.commentsCount}
+                  </Button>
                   {user && user.id !== review.user.id && (
                     <Button
                       variant="ghost"
@@ -243,6 +261,11 @@ export function ReviewList({ gameId }: ReviewListProps) {
                 </div>
               )}
             </CardContent>
+            {expandedComments[review.id] && (
+              <div className="border-t px-6 py-4">
+                <CommentSection targetType="review" targetId={review.id} />
+              </div>
+            )}
           </Card>
         ))}
       </div>

--- a/web/src/queries/comment.ts
+++ b/web/src/queries/comment.ts
@@ -1,0 +1,97 @@
+import { queryOptions } from '@tanstack/react-query'
+import type { Comment, CommentsResponse } from '@/types/comment'
+import { apiFetch } from '@/services/api'
+
+export const reviewCommentsQueryOptions = (
+  reviewId: string,
+  page: number = 0,
+  size: number = 20,
+) => {
+  return queryOptions({
+    queryKey: ['reviews', reviewId, 'comments', page, size],
+    queryFn: async (): Promise<CommentsResponse> => {
+      const res = await apiFetch(
+        `/api/reviews/${reviewId}/comments?page=${page}&size=${size}`,
+      )
+      if (!res.ok) {
+        throw new Error('Failed to fetch review comments')
+      }
+      return res.json()
+    },
+    staleTime: 60 * 1000,
+  })
+}
+
+export const listCommentsQueryOptions = (
+  listId: string,
+  page: number = 0,
+  size: number = 20,
+) => {
+  return queryOptions({
+    queryKey: ['lists', listId, 'comments', page, size],
+    queryFn: async (): Promise<CommentsResponse> => {
+      const res = await apiFetch(
+        `/api/lists/${listId}/comments?page=${page}&size=${size}`,
+      )
+      if (!res.ok) {
+        throw new Error('Failed to fetch list comments')
+      }
+      return res.json()
+    },
+    staleTime: 60 * 1000,
+  })
+}
+
+export const postReviewComment = async (
+  reviewId: string,
+  content: string,
+): Promise<Comment> => {
+  const res = await apiFetch(`/api/reviews/${reviewId}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to post comment')
+  }
+  return res.json()
+}
+
+export const postListComment = async (
+  listId: string,
+  content: string,
+): Promise<Comment> => {
+  const res = await apiFetch(`/api/lists/${listId}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to post comment')
+  }
+  return res.json()
+}
+
+export const updateComment = async (
+  commentId: string,
+  content: string,
+): Promise<Comment> => {
+  const res = await apiFetch(`/api/comments/${commentId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to update comment')
+  }
+  return res.json()
+}
+
+export const deleteComment = async (commentId: string): Promise<void> => {
+  const res = await apiFetch(`/api/comments/${commentId}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok) {
+    throw new Error('Failed to delete comment')
+  }
+}

--- a/web/src/routes/_app/lists/$listId.tsx
+++ b/web/src/routes/_app/lists/$listId.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Gamepad2, Loader2, Lock, Pencil } from 'lucide-react'
 import { toast } from 'sonner'
 import type { GameListDetail } from '@/types/list'
 import { listDetailQueryOptions, toggleListLike } from '@/queries/lists'
+import { CommentSection } from '@/components/comments/comment-section'
 import { ListGameItem } from '@/components/lists/list-game-item'
 import { LikeButton } from '@/components/shared/like-button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -188,6 +189,10 @@ function RouteComponent() {
           </p>
         </div>
       )}
+
+      <Separator className="my-6" />
+
+      <CommentSection targetType="list" targetId={listId} />
     </main>
   )
 }

--- a/web/src/types/comment.ts
+++ b/web/src/types/comment.ts
@@ -1,0 +1,20 @@
+import type { PaginationMetadata } from './game'
+
+export interface CommentUser {
+  id: string
+  pseudo: string
+  picture: string | null
+}
+
+export interface Comment {
+  id: string
+  content: string
+  user: CommentUser
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CommentsResponse {
+  content: Array<Comment>
+  metadata: PaginationMetadata
+}

--- a/web/src/types/list.ts
+++ b/web/src/types/list.ts
@@ -7,6 +7,7 @@ export interface GameListCard {
   isPrivate: boolean
   videoGamesCount: number
   likesCount: number
+  commentsCount: number
   authorPseudo: string
   authorPicture: string | null
   coverUrls: Array<string>
@@ -29,6 +30,7 @@ export interface GameListDetail {
   isPrivate: boolean
   videoGamesCount: number
   likesCount: number
+  commentsCount: number
   authorPseudo: string
   authorPicture: string | null
   entries: Array<GameListEntry>

--- a/web/src/types/review.ts
+++ b/web/src/types/review.ts
@@ -20,6 +20,7 @@ export interface Review {
   isReplay: boolean | null
   likesCount: number
   hasLiked: boolean
+  commentsCount: number
 }
 
 export interface LikeResponse {


### PR DESCRIPTION
## Summary

  - Add full CRUD for comments on reviews and game lists (API + web)
  - New `CommentController` with 6 endpoints: GET/POST for review and list comments, PUT/DELETE for comment management with owner-only authorization
  - New `CommentSection` reusable component with inline editing, optimistic deletes, and pagination
  - Add `commentsCount` to review and game list DTOs
  - Comments are expandable on review cards, always visible on list detail pages
  - Fix hydration mismatch in header caused by SSR/client divergence on `useIsMac`
  - Bruno collection files for all comment endpoints

  ## Test plan

  - [ ] API: 449 tests passing (including 25 new comment controller + service tests)
  - [ ] Web: build succeeds without errors
  - [ ] Post, edit, and delete a comment on a review
  - [ ] Post, edit, and delete a comment on a game list
  - [ ] Verify comment count updates on review cards and list detail
  - [ ] Verify non-authenticated users see "Log in to leave a comment"
  - [ ] Verify edit/delete actions only visible for own comments
  - [ ] No hydration errors in console