### PR TITLE
docs(desktop): add Javadoc to all java files (TE-345)

### DIFF
--- a/desktop/src/main/java/com/seyzeriat/desktop/HelloApplication.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/HelloApplication.java
@@ -32,6 +32,10 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
+/**
+ * The main application class for the Checkpoint desktop administration tool.
+ * This class handles the initialization of the primary stage and navigation between views.
+ */
 public class HelloApplication extends Application {
 
     private Stage primaryStage;
@@ -39,6 +43,14 @@ public class HelloApplication extends Application {
     private Button activeNavButton;
     private String stylesheetUrl;
 
+    /**
+     * The main entry point for all JavaFX applications.
+     * The start method is called after the init method has returned,
+     * and after the system is ready for the application to begin running.
+     *
+     * @param stage the primary stage for this application, onto which
+     *              the application scene can be set.
+     */
     @Override
     public void start(Stage stage) {
         this.primaryStage = stage;
@@ -313,6 +325,13 @@ public class HelloApplication extends Application {
         contentArea.getChildren().setAll(content);
     }
 
+    /**
+     * Creates an FXMLLoader for the specified FXML file.
+     * Uses the DependencyContainer as a controller factory.
+     *
+     * @param fxml the name of the FXML file to load
+     * @return a configured FXMLLoader instance
+     */
     public FXMLLoader createLoader(String fxml) {
         FXMLLoader loader = new FXMLLoader(getClass().getResource(fxml));
         loader.setControllerFactory(com.seyzeriat.desktop.di.DependencyContainer.getInstance()::createController);

--- a/desktop/src/main/java/com/seyzeriat/desktop/Launcher.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/Launcher.java
@@ -2,7 +2,17 @@ package com.seyzeriat.desktop;
 
 import javafx.application.Application;
 
+/**
+ * A launcher class to start the JavaFX application.
+ * This is used as a workaround for JavaFX module path issues when running from an IDE or as a fat JAR.
+ */
 public class Launcher {
+    
+    /**
+     * The main entry point for the launcher.
+     * 
+     * @param args the command line arguments
+     */
     public static void main(String[] args) {
         Application.launch(HelloApplication.class, args);
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/AnalyticsController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/AnalyticsController.java
@@ -49,10 +49,19 @@ public class AnalyticsController {
     private final AnalyticsService analyticsService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified analytics service.
+     *
+     * @param analyticsService the service used to fetch analytics data
+     */
     public AnalyticsController(AnalyticsService analyticsService) {
         this.analyticsService = analyticsService;
     }
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
@@ -70,6 +79,11 @@ public class AnalyticsController {
         fetchAnalytics();
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/BulkImportController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/BulkImportController.java
@@ -46,6 +46,11 @@ public class BulkImportController {
     private final GameService gameService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified game service.
+     *
+     * @param gameService the service used to handle game imports
+     */
     public BulkImportController(GameService gameService) {
         this.gameService = gameService;
     }
@@ -53,6 +58,10 @@ public class BulkImportController {
     /** Guards the polling loop so it can be stopped (e.g. when a new import starts). */
     private volatile boolean polling;
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         topRatedLimitSpinner.setValueFactory(
@@ -220,6 +229,11 @@ public class BulkImportController {
         return sb.toString();
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/GameFormController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/GameFormController.java
@@ -57,11 +57,20 @@ public class GameFormController {
     private final GameService gameService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified game service.
+     *
+     * @param gameService the service used to manage games and fetch catalog options
+     */
     public GameFormController(GameService gameService) {
         this.gameService = gameService;
     }
     private String gameId;
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
@@ -70,6 +79,11 @@ public class GameFormController {
         companiesList.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/ImportGamesController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/ImportGamesController.java
@@ -40,10 +40,19 @@ public class ImportGamesController {
     private final Set<Long> importedIds = new HashSet<>();
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified game service.
+     *
+     * @param gameService the service used to search and import external games
+     */
     public ImportGamesController(GameService gameService) {
         this.gameService = gameService;
     }
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         searchProgress.setVisible(false);
@@ -213,6 +222,11 @@ public class ImportGamesController {
         new Thread(importTask, "import-thread").start();
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/LoginController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/LoginController.java
@@ -29,6 +29,11 @@ public class LoginController {
 
     private final AuthenticationService authService;
 
+    /**
+     * Constructs the controller with the specified authentication service.
+     *
+     * @param authService the service used for user authentication
+     */
     public LoginController(AuthenticationService authService) {
         this.authService = authService;
     }
@@ -39,10 +44,19 @@ public class LoginController {
      */
     private HelloApplication application;
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         errorLabel.setText("");

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/ManageGamesController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/ManageGamesController.java
@@ -51,6 +51,11 @@ public class ManageGamesController {
     private final GameService gameService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified game service.
+     *
+     * @param gameService the service used to manage games
+     */
     public ManageGamesController(GameService gameService) {
         this.gameService = gameService;
     }
@@ -58,6 +63,10 @@ public class ManageGamesController {
     private int currentPage = 0;
     private int totalPages = 1;
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
@@ -72,6 +81,11 @@ public class ManageGamesController {
         fetchGames(currentPage);
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/NewsEditorDialogController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/NewsEditorDialogController.java
@@ -42,10 +42,19 @@ public class NewsEditorDialogController {
     private Runnable onSaved;
     private Runnable onUnauthorized;
 
+    /**
+     * Constructs the controller with the specified news service.
+     *
+     * @param newsService the service used to handle news operations
+     */
     public NewsEditorDialogController(NewsService newsService) {
         this.newsService = newsService;
     }
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/NewsManagementController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/NewsManagementController.java
@@ -74,6 +74,11 @@ public class NewsManagementController {
     private final NewsService newsService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified news service.
+     *
+     * @param newsService the service used for news management operations
+     */
     public NewsManagementController(NewsService newsService) {
         this.newsService = newsService;
     }
@@ -83,6 +88,10 @@ public class NewsManagementController {
     private long totalElements = 0;
     private final List<NewsResult> currentPageData = new ArrayList<>();
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
@@ -120,6 +129,11 @@ public class NewsManagementController {
         fetchNews(currentPage);
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/ReportModerationController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/ReportModerationController.java
@@ -23,6 +23,12 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.layout.HBox;
 
+/**
+ * Controller for the report moderation view.
+ *
+ * <p>Handles displaying paginated generic reports (reviews, comments, etc.)
+ * and provides actions to dismiss reports or delete the reported content.</p>
+ */
 public class ReportModerationController {
 
     @FXML private TableView<ReportResult> reportsTable;
@@ -44,6 +50,12 @@ public class ReportModerationController {
     private final ReviewService reviewService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the required services.
+     *
+     * @param reportService the service handling generic reports
+     * @param reviewService the service handling reviews and comments deletion
+     */
     public ReportModerationController(ReportService reportService, ReviewService reviewService) {
         this.reportService = reportService;
         this.reviewService = reviewService;
@@ -52,6 +64,10 @@ public class ReportModerationController {
     private int currentPage = 0;
     private static final int PAGE_SIZE = 20;
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
@@ -123,6 +139,11 @@ public class ReportModerationController {
         fetchReports(currentPage + 1);
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/ReviewModerationController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/ReviewModerationController.java
@@ -25,6 +25,12 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.layout.HBox;
 
+/**
+ * Controller for the review moderation view.
+ *
+ * <p>Handles displaying paginated reported reviews, and provides actions
+ * to view reports, view the author, ban the author, or delete the review.</p>
+ */
 public class ReviewModerationController {
 
     @FXML private TableView<ReviewResult> reviewsTable;
@@ -45,6 +51,12 @@ public class ReviewModerationController {
     private final UserService userService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the required services.
+     *
+     * @param reviewService the service handling review-related operations
+     * @param userService   the service handling user-related operations
+     */
     public ReviewModerationController(ReviewService reviewService, UserService userService) {
         this.reviewService = reviewService;
         this.userService = userService;
@@ -53,6 +65,10 @@ public class ReviewModerationController {
     private int currentPage = 0;
     private static final int PAGE_SIZE = 20;
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
@@ -121,6 +137,11 @@ public class ReviewModerationController {
         fetchReviews(currentPage + 1);
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/ReviewReportsController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/ReviewReportsController.java
@@ -49,6 +49,11 @@ public class ReviewReportsController {
     private final ReviewService reviewService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified review service.
+     *
+     * @param reviewService the service used to fetch review reports
+     */
     public ReviewReportsController(ReviewService reviewService) {
         this.reviewService = reviewService;
     }
@@ -57,6 +62,10 @@ public class ReviewReportsController {
     private int currentPage = 0;
     private static final int PAGE_SIZE = 20;
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
@@ -69,6 +78,11 @@ public class ReviewReportsController {
                 new SimpleStringProperty(cellData.getValue().getCreatedAt()));
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/UserDetailController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/UserDetailController.java
@@ -51,18 +51,32 @@ public class UserDetailController {
     private final UserService userService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified user service.
+     *
+     * @param userService the service used to fetch and modify user details
+     */
     public UserDetailController(UserService userService) {
         this.userService = userService;
     }
     private String userId;
     private UserDetailResult currentUser;
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
         detailContent.setVisible(false);
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/controller/UserManagementController.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/controller/UserManagementController.java
@@ -43,10 +43,19 @@ public class UserManagementController {
     private final UserService userService;
     private HelloApplication application;
 
+    /**
+     * Constructs the controller with the specified user service.
+     *
+     * @param userService the service used for user management operations
+     */
     public UserManagementController(UserService userService) {
         this.userService = userService;
     }
 
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the fxml file has been loaded.
+     */
     @FXML
     public void initialize() {
         loadingIndicator.setVisible(false);
@@ -118,6 +127,11 @@ public class UserManagementController {
         fetchUsers();
     }
 
+    /**
+     * Sets the main application instance.
+     *
+     * @param application the main application instance
+     */
     public void setApplication(HelloApplication application) {
         this.application = application;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/di/DependencyContainer.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/di/DependencyContainer.java
@@ -3,6 +3,10 @@ package com.seyzeriat.desktop.di;
 import com.seyzeriat.desktop.service.*;
 import com.seyzeriat.desktop.service.impl.*;
 
+/**
+ * A simple dependency injection container for managing service instances
+ * and creating controllers with their required dependencies.
+ */
 public class DependencyContainer {
 
     private static DependencyContainer instance;
@@ -25,6 +29,11 @@ public class DependencyContainer {
         this.reviewService = new ReviewApiClient(authenticationService);
     }
 
+    /**
+     * Gets the singleton instance of the DependencyContainer.
+     *
+     * @return the singleton instance
+     */
     public static synchronized DependencyContainer getInstance() {
         if (instance == null) {
             instance = new DependencyContainer();
@@ -32,6 +41,13 @@ public class DependencyContainer {
         return instance;
     }
 
+    /**
+     * Creates a controller instance of the specified type, injecting any required dependencies.
+     *
+     * @param type the class of the controller to create
+     * @return an instance of the specified controller class
+     * @throws RuntimeException if the controller cannot be created
+     */
     public Object createController(Class<?> type) {
         try {
             if (type.equals(com.seyzeriat.desktop.controller.LoginController.class)) {

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/AnalyticsResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/AnalyticsResult.java
@@ -18,62 +18,194 @@ public class AnalyticsResult {
     private List<TopGame> topReviewedGames;
     private List<TopReviewer> topReviewers;
 
+    /**
+     * Default constructor for Jackson.
+     */
     public AnalyticsResult() {}
 
+    /**
+     * Gets the total number of users.
+     * @return total users
+     */
     public long getTotalUsers() { return totalUsers; }
+    
+    /**
+     * Sets the total number of users.
+     * @param totalUsers total users
+     */
     public void setTotalUsers(long totalUsers) { this.totalUsers = totalUsers; }
 
+    /**
+     * Gets the number of active users.
+     * @return active users
+     */
     public long getActiveUsers() { return activeUsers; }
+    
+    /**
+     * Sets the number of active users.
+     * @param activeUsers active users
+     */
     public void setActiveUsers(long activeUsers) { this.activeUsers = activeUsers; }
 
+    /**
+     * Gets the total number of games.
+     * @return total games
+     */
     public long getTotalGames() { return totalGames; }
+    
+    /**
+     * Sets the total number of games.
+     * @param totalGames total games
+     */
     public void setTotalGames(long totalGames) { this.totalGames = totalGames; }
 
+    /**
+     * Gets the total number of reviews.
+     * @return total reviews
+     */
     public long getTotalReviews() { return totalReviews; }
+    
+    /**
+     * Sets the total number of reviews.
+     * @param totalReviews total reviews
+     */
     public void setTotalReviews(long totalReviews) { this.totalReviews = totalReviews; }
 
+    /**
+     * Gets the number of open reports.
+     * @return open reports
+     */
     public long getOpenReports() { return openReports; }
+    
+    /**
+     * Sets the number of open reports.
+     * @param openReports open reports
+     */
     public void setOpenReports(long openReports) { this.openReports = openReports; }
 
+    /**
+     * Gets the list of top reviewed games.
+     * @return top reviewed games
+     */
     public List<TopGame> getTopReviewedGames() { return topReviewedGames; }
+    
+    /**
+     * Sets the list of top reviewed games.
+     * @param topReviewedGames top reviewed games
+     */
     public void setTopReviewedGames(List<TopGame> topReviewedGames) { this.topReviewedGames = topReviewedGames; }
 
+    /**
+     * Gets the list of top reviewers.
+     * @return top reviewers
+     */
     public List<TopReviewer> getTopReviewers() { return topReviewers; }
+    
+    /**
+     * Sets the list of top reviewers.
+     * @param topReviewers top reviewers
+     */
     public void setTopReviewers(List<TopReviewer> topReviewers) { this.topReviewers = topReviewers; }
 
+    /**
+     * DTO representing a top reviewed game in analytics.
+     */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class TopGame {
         private String id;
         private String title;
         private long reviewCount;
 
+        /**
+         * Default constructor for Jackson.
+         */
         public TopGame() {}
 
+        /**
+         * Gets the game ID.
+         * @return game ID
+         */
         public String getId() { return id; }
+        
+        /**
+         * Sets the game ID.
+         * @param id game ID
+         */
         public void setId(String id) { this.id = id; }
 
+        /**
+         * Gets the game title.
+         * @return game title
+         */
         public String getTitle() { return title; }
+        
+        /**
+         * Sets the game title.
+         * @param title game title
+         */
         public void setTitle(String title) { this.title = title; }
 
+        /**
+         * Gets the review count for the game.
+         * @return review count
+         */
         public long getReviewCount() { return reviewCount; }
+        
+        /**
+         * Sets the review count for the game.
+         * @param reviewCount review count
+         */
         public void setReviewCount(long reviewCount) { this.reviewCount = reviewCount; }
     }
 
+    /**
+     * DTO representing a top reviewer in analytics.
+     */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class TopReviewer {
         private String id;
         private String username;
         private long reviewCount;
 
+        /**
+         * Default constructor for Jackson.
+         */
         public TopReviewer() {}
 
+        /**
+         * Gets the reviewer ID.
+         * @return reviewer ID
+         */
         public String getId() { return id; }
+        
+        /**
+         * Sets the reviewer ID.
+         * @param id reviewer ID
+         */
         public void setId(String id) { this.id = id; }
 
+        /**
+         * Gets the reviewer's username.
+         * @return username
+         */
         public String getUsername() { return username; }
+        
+        /**
+         * Sets the reviewer's username.
+         * @param username username
+         */
         public void setUsername(String username) { this.username = username; }
 
+        /**
+         * Gets the user's review count.
+         * @return review count
+         */
         public long getReviewCount() { return reviewCount; }
+        
+        /**
+         * Sets the user's review count.
+         * @param reviewCount review count
+         */
         public void setReviewCount(long reviewCount) { this.reviewCount = reviewCount; }
     }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/CatalogOption.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/CatalogOption.java
@@ -14,24 +14,60 @@ public class CatalogOption {
     private String id;
     private String name;
 
+    /**
+     * Default constructor for Jackson.
+     */
     public CatalogOption() {}
 
+    /**
+     * Constructs a CatalogOption with a specific ID and name.
+     * @param id the option ID
+     * @param name the option name
+     */
     public CatalogOption(String id, String name) {
         this.id = id;
         this.name = name;
     }
 
+    /**
+     * Gets the option ID.
+     * @return the option ID
+     */
     public String getId() { return id; }
+    
+    /**
+     * Sets the option ID.
+     * @param id the option ID
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the option name.
+     * @return the option name
+     */
     public String getName() { return name; }
+    
+    /**
+     * Sets the option name.
+     * @param name the option name
+     */
     public void setName(String name) { this.name = name; }
 
+    /**
+     * Returns a string representation of the option.
+     * @return the option name or an empty string if null
+     */
     @Override
     public String toString() {
         return name == null ? "" : name;
     }
 
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     * Equality is determined by comparing IDs.
+     * @param o the reference object with which to compare
+     * @return true if this object is the same as the obj argument; false otherwise
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -39,6 +75,10 @@ public class CatalogOption {
         return Objects.equals(id, that.id);
     }
 
+    /**
+     * Returns a hash code value for the object based on its ID.
+     * @return a hash code value for this object
+     */
     @Override
     public int hashCode() {
         return Objects.hashCode(id);

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/ExternalGameResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/ExternalGameResult.java
@@ -12,17 +12,64 @@ public class ExternalGameResult {
     private Integer releaseYear;
     private String coverUrl;
 
+    /**
+     * Default constructor for ExternalGameResult.
+     */
     public ExternalGameResult() {}
 
+    /**
+     * Gets the external ID of the game.
+     *
+     * @return the external ID
+     */
     public Long getExternalId() { return externalId; }
+
+    /**
+     * Sets the external ID of the game.
+     *
+     * @param externalId the external ID to set
+     */
     public void setExternalId(Long externalId) { this.externalId = externalId; }
 
+    /**
+     * Gets the title of the game.
+     *
+     * @return the title
+     */
     public String getTitle() { return title; }
+
+    /**
+     * Sets the title of the game.
+     *
+     * @param title the title to set
+     */
     public void setTitle(String title) { this.title = title; }
 
+    /**
+     * Gets the release year of the game.
+     *
+     * @return the release year
+     */
     public Integer getReleaseYear() { return releaseYear; }
+
+    /**
+     * Sets the release year of the game.
+     *
+     * @param releaseYear the release year to set
+     */
     public void setReleaseYear(Integer releaseYear) { this.releaseYear = releaseYear; }
 
+    /**
+     * Gets the cover URL of the game.
+     *
+     * @return the cover URL
+     */
     public String getCoverUrl() { return coverUrl; }
+
+    /**
+     * Sets the cover URL of the game.
+     *
+     * @param coverUrl the cover URL to set
+     */
     public void setCoverUrl(String coverUrl) { this.coverUrl = coverUrl; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/GameDetailResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/GameDetailResult.java
@@ -25,45 +25,165 @@ public class GameDetailResult {
     private List<NamedRef> platforms;
     private List<NamedRef> companies;
 
+    /**
+     * Default constructor for Jackson.
+     */
     public GameDetailResult() {}
 
+    /**
+     * Gets the game ID.
+     * @return game ID
+     */
     public String getId() { return id; }
+    
+    /**
+     * Sets the game ID.
+     * @param id game ID
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the game title.
+     * @return game title
+     */
     public String getTitle() { return title; }
+    
+    /**
+     * Sets the game title.
+     * @param title game title
+     */
     public void setTitle(String title) { this.title = title; }
 
+    /**
+     * Gets the game description.
+     * @return game description
+     */
     public String getDescription() { return description; }
+    
+    /**
+     * Sets the game description.
+     * @param description game description
+     */
     public void setDescription(String description) { this.description = description; }
 
+    /**
+     * Gets the game cover URL.
+     * @return cover URL
+     */
     public String getCoverUrl() { return coverUrl; }
+    
+    /**
+     * Sets the game cover URL.
+     * @param coverUrl cover URL
+     */
     public void setCoverUrl(String coverUrl) { this.coverUrl = coverUrl; }
 
+    /**
+     * Gets the game artwork URL.
+     * @return artwork URL
+     */
     public String getArtworkUrl() { return artworkUrl; }
+    
+    /**
+     * Sets the game artwork URL.
+     * @param artworkUrl artwork URL
+     */
     public void setArtworkUrl(String artworkUrl) { this.artworkUrl = artworkUrl; }
 
+    /**
+     * Gets the game's YouTube trailer ID.
+     * @return trailer YouTube ID
+     */
     public String getTrailerYoutubeId() { return trailerYoutubeId; }
+    
+    /**
+     * Sets the game's YouTube trailer ID.
+     * @param trailerYoutubeId trailer YouTube ID
+     */
     public void setTrailerYoutubeId(String trailerYoutubeId) { this.trailerYoutubeId = trailerYoutubeId; }
 
+    /**
+     * Gets the normal time to beat in seconds.
+     * @return normal time to beat
+     */
     public Long getTimeToBeatNormally() { return timeToBeatNormally; }
+    
+    /**
+     * Sets the normal time to beat in seconds.
+     * @param timeToBeatNormally normal time to beat
+     */
     public void setTimeToBeatNormally(Long timeToBeatNormally) { this.timeToBeatNormally = timeToBeatNormally; }
 
+    /**
+     * Gets the hasty time to beat in seconds.
+     * @return hasty time to beat
+     */
     public Long getTimeToBeatHastily() { return timeToBeatHastily; }
+    
+    /**
+     * Sets the hasty time to beat in seconds.
+     * @param timeToBeatHastily hasty time to beat
+     */
     public void setTimeToBeatHastily(Long timeToBeatHastily) { this.timeToBeatHastily = timeToBeatHastily; }
 
+    /**
+     * Gets the complete time to beat in seconds.
+     * @return complete time to beat
+     */
     public Long getTimeToBeatCompletely() { return timeToBeatCompletely; }
+    
+    /**
+     * Sets the complete time to beat in seconds.
+     * @param timeToBeatCompletely complete time to beat
+     */
     public void setTimeToBeatCompletely(Long timeToBeatCompletely) { this.timeToBeatCompletely = timeToBeatCompletely; }
 
+    /**
+     * Gets the game's release date.
+     * @return release date
+     */
     public LocalDate getReleaseDate() { return releaseDate; }
+    
+    /**
+     * Sets the game's release date.
+     * @param releaseDate release date
+     */
     public void setReleaseDate(LocalDate releaseDate) { this.releaseDate = releaseDate; }
 
+    /**
+     * Gets the list of genres.
+     * @return genres list
+     */
     public List<NamedRef> getGenres() { return genres; }
+    
+    /**
+     * Sets the list of genres.
+     * @param genres genres list
+     */
     public void setGenres(List<NamedRef> genres) { this.genres = genres; }
 
+    /**
+     * Gets the list of platforms.
+     * @return platforms list
+     */
     public List<NamedRef> getPlatforms() { return platforms; }
+    
+    /**
+     * Sets the list of platforms.
+     * @param platforms platforms list
+     */
     public void setPlatforms(List<NamedRef> platforms) { this.platforms = platforms; }
 
+    /**
+     * Gets the list of companies.
+     * @return companies list
+     */
     public List<NamedRef> getCompanies() { return companies; }
+    
+    /**
+     * Sets the list of companies.
+     * @param companies companies list
+     */
     public void setCompanies(List<NamedRef> companies) { this.companies = companies; }
 
     /**
@@ -74,12 +194,33 @@ public class GameDetailResult {
         private String id;
         private String name;
 
+        /**
+         * Default constructor for Jackson.
+         */
         public NamedRef() {}
 
+        /**
+         * Gets the reference ID.
+         * @return reference ID
+         */
         public String getId() { return id; }
+        
+        /**
+         * Sets the reference ID.
+         * @param id reference ID
+         */
         public void setId(String id) { this.id = id; }
 
+        /**
+         * Gets the reference name.
+         * @return reference name
+         */
         public String getName() { return name; }
+        
+        /**
+         * Sets the reference name.
+         * @param name reference name
+         */
         public void setName(String name) { this.name = name; }
     }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/GameFormPayload.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/GameFormPayload.java
@@ -24,41 +24,176 @@ public class GameFormPayload {
     private Set<String> platformIds;
     private Set<String> companyIds;
 
+    /**
+     * Default constructor for GameFormPayload.
+     */
     public GameFormPayload() {}
 
+    /**
+     * Gets the title of the game.
+     *
+     * @return the title
+     */
     public String getTitle() { return title; }
+
+    /**
+     * Sets the title of the game.
+     *
+     * @param title the title to set
+     */
     public void setTitle(String title) { this.title = title; }
 
+    /**
+     * Gets the description of the game.
+     *
+     * @return the description
+     */
     public String getDescription() { return description; }
+
+    /**
+     * Sets the description of the game.
+     *
+     * @param description the description to set
+     */
     public void setDescription(String description) { this.description = description; }
 
+    /**
+     * Gets the cover URL of the game.
+     *
+     * @return the cover URL
+     */
     public String getCoverUrl() { return coverUrl; }
+
+    /**
+     * Sets the cover URL of the game.
+     *
+     * @param coverUrl the cover URL to set
+     */
     public void setCoverUrl(String coverUrl) { this.coverUrl = coverUrl; }
 
+    /**
+     * Gets the artwork URL of the game.
+     *
+     * @return the artwork URL
+     */
     public String getArtworkUrl() { return artworkUrl; }
+
+    /**
+     * Sets the artwork URL of the game.
+     *
+     * @param artworkUrl the artwork URL to set
+     */
     public void setArtworkUrl(String artworkUrl) { this.artworkUrl = artworkUrl; }
 
+    /**
+     * Gets the YouTube ID of the game trailer.
+     *
+     * @return the YouTube ID
+     */
     public String getTrailerYoutubeId() { return trailerYoutubeId; }
+
+    /**
+     * Sets the YouTube ID of the game trailer.
+     *
+     * @param trailerYoutubeId the YouTube ID to set
+     */
     public void setTrailerYoutubeId(String trailerYoutubeId) { this.trailerYoutubeId = trailerYoutubeId; }
 
+    /**
+     * Gets the time to beat the game normally.
+     *
+     * @return the normal time to beat in seconds
+     */
     public Long getTimeToBeatNormally() { return timeToBeatNormally; }
+
+    /**
+     * Sets the time to beat the game normally.
+     *
+     * @param timeToBeatNormally the normal time to beat to set
+     */
     public void setTimeToBeatNormally(Long timeToBeatNormally) { this.timeToBeatNormally = timeToBeatNormally; }
 
+    /**
+     * Gets the time to beat the game hastily.
+     *
+     * @return the hasty time to beat in seconds
+     */
     public Long getTimeToBeatHastily() { return timeToBeatHastily; }
+
+    /**
+     * Sets the time to beat the game hastily.
+     *
+     * @param timeToBeatHastily the hasty time to beat to set
+     */
     public void setTimeToBeatHastily(Long timeToBeatHastily) { this.timeToBeatHastily = timeToBeatHastily; }
 
+    /**
+     * Gets the time to beat the game completely.
+     *
+     * @return the complete time to beat in seconds
+     */
     public Long getTimeToBeatCompletely() { return timeToBeatCompletely; }
+
+    /**
+     * Sets the time to beat the game completely.
+     *
+     * @param timeToBeatCompletely the complete time to beat to set
+     */
     public void setTimeToBeatCompletely(Long timeToBeatCompletely) { this.timeToBeatCompletely = timeToBeatCompletely; }
 
+    /**
+     * Gets the release date of the game.
+     *
+     * @return the release date
+     */
     public LocalDate getReleaseDate() { return releaseDate; }
+
+    /**
+     * Sets the release date of the game.
+     *
+     * @param releaseDate the release date to set
+     */
     public void setReleaseDate(LocalDate releaseDate) { this.releaseDate = releaseDate; }
 
+    /**
+     * Gets the set of genre IDs associated with the game.
+     *
+     * @return the set of genre IDs
+     */
     public Set<String> getGenreIds() { return genreIds; }
+
+    /**
+     * Sets the set of genre IDs associated with the game.
+     *
+     * @param genreIds the set of genre IDs to set
+     */
     public void setGenreIds(Set<String> genreIds) { this.genreIds = genreIds; }
 
+    /**
+     * Gets the set of platform IDs associated with the game.
+     *
+     * @return the set of platform IDs
+     */
     public Set<String> getPlatformIds() { return platformIds; }
+
+    /**
+     * Sets the set of platform IDs associated with the game.
+     *
+     * @param platformIds the set of platform IDs to set
+     */
     public void setPlatformIds(Set<String> platformIds) { this.platformIds = platformIds; }
 
+    /**
+     * Gets the set of company IDs associated with the game.
+     *
+     * @return the set of company IDs
+     */
     public Set<String> getCompanyIds() { return companyIds; }
+
+    /**
+     * Sets the set of company IDs associated with the game.
+     *
+     * @param companyIds the set of company IDs to set
+     */
     public void setCompanyIds(Set<String> companyIds) { this.companyIds = companyIds; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/GameSummaryResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/GameSummaryResult.java
@@ -15,17 +15,56 @@ public class GameSummaryResult {
     private String coverUrl;
     private LocalDate releaseDate;
 
+    /**
+     * Default constructor for Jackson.
+     */
     public GameSummaryResult() {}
 
+    /**
+     * Gets the game ID.
+     * @return the game ID
+     */
     public String getId() { return id; }
+
+    /**
+     * Sets the game ID.
+     * @param id the game ID
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the title of the game.
+     * @return the game title
+     */
     public String getTitle() { return title; }
+
+    /**
+     * Sets the title of the game.
+     * @param title the game title
+     */
     public void setTitle(String title) { this.title = title; }
 
+    /**
+     * Gets the cover image URL.
+     * @return the cover URL
+     */
     public String getCoverUrl() { return coverUrl; }
+
+    /**
+     * Sets the cover image URL.
+     * @param coverUrl the cover URL
+     */
     public void setCoverUrl(String coverUrl) { this.coverUrl = coverUrl; }
 
+    /**
+     * Gets the release date of the game.
+     * @return the release date
+     */
     public LocalDate getReleaseDate() { return releaseDate; }
+
+    /**
+     * Sets the release date of the game.
+     * @param releaseDate the release date
+     */
     public void setReleaseDate(LocalDate releaseDate) { this.releaseDate = releaseDate; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/ImportJobStatus.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/ImportJobStatus.java
@@ -23,50 +23,193 @@ public class ImportJobStatus {
     private List<String> errors;
     private String errorMessage;
 
+    /**
+     * Default constructor for ImportJobStatus.
+     */
     public ImportJobStatus() {}
 
+    /**
+     * Gets the ID of the import job.
+     *
+     * @return the job ID
+     */
     public String getJobId() { return jobId; }
+
+    /**
+     * Sets the ID of the import job.
+     *
+     * @param jobId the job ID to set
+     */
     public void setJobId(String jobId) { this.jobId = jobId; }
 
+    /**
+     * Gets the type of the import job.
+     *
+     * @return the job type
+     */
     public String getType() { return type; }
+
+    /**
+     * Sets the type of the import job.
+     *
+     * @param type the job type to set
+     */
     public void setType(String type) { this.type = type; }
 
+    /**
+     * Gets the state of the import job.
+     *
+     * @return the job state
+     */
     public String getState() { return state; }
+
+    /**
+     * Sets the state of the import job.
+     *
+     * @param state the job state to set
+     */
     public void setState(String state) { this.state = state; }
 
+    /**
+     * Gets the requested limit of items to import.
+     *
+     * @return the requested limit
+     */
     public int getRequestedLimit() { return requestedLimit; }
+
+    /**
+     * Sets the requested limit of items to import.
+     *
+     * @param requestedLimit the requested limit to set
+     */
     public void setRequestedLimit(int requestedLimit) { this.requestedLimit = requestedLimit; }
 
+    /**
+     * Gets the minimum rating count required for import.
+     *
+     * @return the minimum rating count
+     */
     public int getMinRatingCount() { return minRatingCount; }
+
+    /**
+     * Sets the minimum rating count required for import.
+     *
+     * @param minRatingCount the minimum rating count to set
+     */
     public void setMinRatingCount(int minRatingCount) { this.minRatingCount = minRatingCount; }
 
+    /**
+     * Gets the total number of items fetched.
+     *
+     * @return the total fetched count
+     */
     public int getTotalFetched() { return totalFetched; }
+
+    /**
+     * Sets the total number of items fetched.
+     *
+     * @param totalFetched the total fetched count to set
+     */
     public void setTotalFetched(int totalFetched) { this.totalFetched = totalFetched; }
 
+    /**
+     * Gets the number of items processed so far.
+     *
+     * @return the processed count
+     */
     public int getProcessed() { return processed; }
+
+    /**
+     * Sets the number of items processed.
+     *
+     * @param processed the processed count to set
+     */
     public void setProcessed(int processed) { this.processed = processed; }
 
+    /**
+     * Gets the number of items successfully imported.
+     *
+     * @return the imported count
+     */
     public int getImported() { return imported; }
+
+    /**
+     * Sets the number of items successfully imported.
+     *
+     * @param imported the imported count to set
+     */
     public void setImported(int imported) { this.imported = imported; }
 
+    /**
+     * Gets the number of items skipped during import.
+     *
+     * @return the skipped count
+     */
     public int getSkipped() { return skipped; }
+
+    /**
+     * Sets the number of items skipped during import.
+     *
+     * @param skipped the skipped count to set
+     */
     public void setSkipped(int skipped) { this.skipped = skipped; }
 
+    /**
+     * Gets the number of items that failed to import.
+     *
+     * @return the failed count
+     */
     public int getFailed() { return failed; }
+
+    /**
+     * Sets the number of items that failed to import.
+     *
+     * @param failed the failed count to set
+     */
     public void setFailed(int failed) { this.failed = failed; }
 
+    /**
+     * Gets the list of error messages encountered during import.
+     *
+     * @return the list of errors
+     */
     public List<String> getErrors() { return errors; }
+
+    /**
+     * Sets the list of error messages encountered during import.
+     *
+     * @param errors the list of errors to set
+     */
     public void setErrors(List<String> errors) { this.errors = errors; }
 
+    /**
+     * Gets a general error message if the job failed as a whole.
+     *
+     * @return the general error message
+     */
     public String getErrorMessage() { return errorMessage; }
+
+    /**
+     * Sets a general error message for the job.
+     *
+     * @param errorMessage the error message to set
+     */
     public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
 
-    /** Whether the job has reached a terminal state. */
+    /**
+     * Checks whether the job has reached a terminal state (COMPLETED or FAILED).
+     *
+     * @return true if terminal, false otherwise
+     */
     public boolean isTerminal() {
         return "COMPLETED".equals(state) || "FAILED".equals(state);
     }
 
-    /** Whether the job finished successfully. */
+    /**
+     * Checks whether the job finished with a FAILED state.
+     *
+     * @return true if failed, false otherwise
+     */
     public boolean isFailed() {
         return "FAILED".equals(state);
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/ImportedGameResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/ImportedGameResult.java
@@ -12,17 +12,64 @@ public class ImportedGameResult {
     private String description;
     private String coverUrl;
 
+    /**
+     * Default constructor for ImportedGameResult.
+     */
     public ImportedGameResult() {}
 
+    /**
+     * Gets the ID of the imported game.
+     *
+     * @return the game ID
+     */
     public String getId() { return id; }
+
+    /**
+     * Sets the ID of the imported game.
+     *
+     * @param id the game ID to set
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the title of the imported game.
+     *
+     * @return the game title
+     */
     public String getTitle() { return title; }
+
+    /**
+     * Sets the title of the imported game.
+     *
+     * @param title the game title to set
+     */
     public void setTitle(String title) { this.title = title; }
 
+    /**
+     * Gets the description of the imported game.
+     *
+     * @return the game description
+     */
     public String getDescription() { return description; }
+
+    /**
+     * Sets the description of the imported game.
+     *
+     * @param description the game description to set
+     */
     public void setDescription(String description) { this.description = description; }
 
+    /**
+     * Gets the cover URL of the imported game.
+     *
+     * @return the cover URL
+     */
     public String getCoverUrl() { return coverUrl; }
+
+    /**
+     * Sets the cover URL of the imported game.
+     *
+     * @param coverUrl the cover URL to set
+     */
     public void setCoverUrl(String coverUrl) { this.coverUrl = coverUrl; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/LoginResponseDto.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/LoginResponseDto.java
@@ -12,11 +12,36 @@ public class LoginResponseDto {
     private String accessToken;
     private String refreshToken;
 
+    /**
+     * Default constructor for LoginResponseDto.
+     */
     public LoginResponseDto() {}
 
+    /**
+     * Gets the access token.
+     *
+     * @return the access token
+     */
     public String getAccessToken() { return accessToken; }
+
+    /**
+     * Sets the access token.
+     *
+     * @param accessToken the access token to set
+     */
     public void setAccessToken(String accessToken) { this.accessToken = accessToken; }
 
+    /**
+     * Gets the refresh token.
+     *
+     * @return the refresh token
+     */
     public String getRefreshToken() { return refreshToken; }
+
+    /**
+     * Sets the refresh token.
+     *
+     * @param refreshToken the refresh token to set
+     */
     public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/NewsAuthorResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/NewsAuthorResult.java
@@ -11,14 +11,50 @@ public class NewsAuthorResult {
     private String pseudo;
     private String picture;
 
+    /**
+     * Default constructor for NewsAuthorResult.
+     */
     public NewsAuthorResult() {}
 
+    /**
+     * Gets the ID of the news author.
+     *
+     * @return the author ID
+     */
     public String getId() { return id; }
+
+    /**
+     * Sets the ID of the news author.
+     *
+     * @param id the author ID to set
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the pseudo or username of the news author.
+     *
+     * @return the pseudo
+     */
     public String getPseudo() { return pseudo; }
+
+    /**
+     * Sets the pseudo or username of the news author.
+     *
+     * @param pseudo the pseudo to set
+     */
     public void setPseudo(String pseudo) { this.pseudo = pseudo; }
 
+    /**
+     * Gets the profile picture URL of the news author.
+     *
+     * @return the picture URL
+     */
     public String getPicture() { return picture; }
+
+    /**
+     * Sets the profile picture URL of the news author.
+     *
+     * @param picture the picture URL to set
+     */
     public void setPicture(String picture) { this.picture = picture; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/NewsRequestPayload.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/NewsRequestPayload.java
@@ -12,20 +12,63 @@ public class NewsRequestPayload {
     private String description;
     private String picture;
 
+    /**
+     * Default constructor for NewsRequestPayload.
+     */
     public NewsRequestPayload() {}
 
+    /**
+     * Constructs a new NewsRequestPayload with the given title, description, and picture.
+     *
+     * @param title the title of the news article
+     * @param description the description or markdown content of the news article
+     * @param picture the cover image URL
+     */
     public NewsRequestPayload(String title, String description, String picture) {
         this.title = title;
         this.description = description;
         this.picture = picture;
     }
 
+    /**
+     * Gets the title of the news article.
+     *
+     * @return the title
+     */
     public String getTitle() { return title; }
+
+    /**
+     * Sets the title of the news article.
+     *
+     * @param title the title to set
+     */
     public void setTitle(String title) { this.title = title; }
 
+    /**
+     * Gets the description of the news article.
+     *
+     * @return the description
+     */
     public String getDescription() { return description; }
+
+    /**
+     * Sets the description of the news article.
+     *
+     * @param description the description to set
+     */
     public void setDescription(String description) { this.description = description; }
 
+    /**
+     * Gets the picture URL of the news article.
+     *
+     * @return the picture URL
+     */
     public String getPicture() { return picture; }
+
+    /**
+     * Sets the picture URL of the news article.
+     *
+     * @param picture the picture URL to set
+     */
     public void setPicture(String picture) { this.picture = picture; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/NewsResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/NewsResult.java
@@ -20,44 +20,184 @@ public class NewsResult {
     private String feedName;
     private String videoGameId;
 
+    /**
+     * Default constructor for NewsResult.
+     */
     public NewsResult() {}
 
+    /**
+     * Gets the ID of the news article.
+     *
+     * @return the ID
+     */
     public String getId() { return id; }
+
+    /**
+     * Sets the ID of the news article.
+     *
+     * @param id the ID to set
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the title of the news article.
+     *
+     * @return the title
+     */
     public String getTitle() { return title; }
+
+    /**
+     * Sets the title of the news article.
+     *
+     * @param title the title to set
+     */
     public void setTitle(String title) { this.title = title; }
 
+    /**
+     * Gets the description of the news article.
+     *
+     * @return the description
+     */
     public String getDescription() { return description; }
+
+    /**
+     * Sets the description of the news article.
+     *
+     * @param description the description to set
+     */
     public void setDescription(String description) { this.description = description; }
 
+    /**
+     * Gets the picture URL of the news article.
+     *
+     * @return the picture URL
+     */
     public String getPicture() { return picture; }
+
+    /**
+     * Sets the picture URL of the news article.
+     *
+     * @param picture the picture URL to set
+     */
     public void setPicture(String picture) { this.picture = picture; }
 
+    /**
+     * Gets the publish date of the news article.
+     *
+     * @return the published at date
+     */
     public String getPublishedAt() { return publishedAt; }
+
+    /**
+     * Sets the publish date of the news article.
+     *
+     * @param publishedAt the published at date to set
+     */
     public void setPublishedAt(String publishedAt) { this.publishedAt = publishedAt; }
 
+    /**
+     * Gets the creation date of the news article.
+     *
+     * @return the created at date
+     */
     public String getCreatedAt() { return createdAt; }
+
+    /**
+     * Sets the creation date of the news article.
+     *
+     * @param createdAt the created at date to set
+     */
     public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
 
+    /**
+     * Gets the last update date of the news article.
+     *
+     * @return the updated at date
+     */
     public String getUpdatedAt() { return updatedAt; }
+
+    /**
+     * Sets the last update date of the news article.
+     *
+     * @param updatedAt the updated at date to set
+     */
     public void setUpdatedAt(String updatedAt) { this.updatedAt = updatedAt; }
 
+    /**
+     * Gets the author of the news article.
+     *
+     * @return the author
+     */
     public NewsAuthorResult getAuthor() { return author; }
+
+    /**
+     * Sets the author of the news article.
+     *
+     * @param author the author to set
+     */
     public void setAuthor(NewsAuthorResult author) { this.author = author; }
 
+    /**
+     * Gets the source of the news article.
+     *
+     * @return the source
+     */
     public String getSource() { return source; }
+
+    /**
+     * Sets the source of the news article.
+     *
+     * @param source the source to set
+     */
     public void setSource(String source) { this.source = source; }
 
+    /**
+     * Gets the external URL of the news article.
+     *
+     * @return the external URL
+     */
     public String getExternalUrl() { return externalUrl; }
+
+    /**
+     * Sets the external URL of the news article.
+     *
+     * @param externalUrl the external URL to set
+     */
     public void setExternalUrl(String externalUrl) { this.externalUrl = externalUrl; }
 
+    /**
+     * Gets the feed name of the news article.
+     *
+     * @return the feed name
+     */
     public String getFeedName() { return feedName; }
+
+    /**
+     * Sets the feed name of the news article.
+     *
+     * @param feedName the feed name to set
+     */
     public void setFeedName(String feedName) { this.feedName = feedName; }
 
+    /**
+     * Gets the video game ID associated with the news article.
+     *
+     * @return the video game ID
+     */
     public String getVideoGameId() { return videoGameId; }
+
+    /**
+     * Sets the video game ID associated with the news article.
+     *
+     * @param videoGameId the video game ID to set
+     */
     public void setVideoGameId(String videoGameId) { this.videoGameId = videoGameId; }
 
+    /**
+     * Checks if the news article is published.
+     *
+     * @return true if published, false otherwise
+     */
     public boolean isPublished() {
         return publishedAt != null && !publishedAt.isBlank();
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/PagedResponse.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/PagedResponse.java
@@ -14,12 +14,37 @@ public class PagedResponse<T> {
     private List<T> content;
     private PageMetadata metadata;
 
+    /**
+     * Default constructor for PagedResponse.
+     */
     public PagedResponse() {}
 
+    /**
+     * Gets the content of the page.
+     *
+     * @return the list of content items
+     */
     public List<T> getContent() { return content; }
+
+    /**
+     * Sets the content of the page.
+     *
+     * @param content the list of content items to set
+     */
     public void setContent(List<T> content) { this.content = content; }
 
+    /**
+     * Gets the metadata of the page.
+     *
+     * @return the page metadata
+     */
     public PageMetadata getMetadata() { return metadata; }
+
+    /**
+     * Sets the metadata of the page.
+     *
+     * @param metadata the page metadata to set
+     */
     public void setMetadata(PageMetadata metadata) { this.metadata = metadata; }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -29,18 +54,65 @@ public class PagedResponse<T> {
         private long totalElements;
         private int totalPages;
 
+        /**
+         * Default constructor for PageMetadata.
+         */
         public PageMetadata() {}
 
+        /**
+         * Gets the current page number (0-indexed).
+         *
+         * @return the page number
+         */
         public int getPage() { return page; }
+
+        /**
+         * Sets the current page number (0-indexed).
+         *
+         * @param page the page number to set
+         */
         public void setPage(int page) { this.page = page; }
 
+        /**
+         * Gets the size of the page (number of elements per page).
+         *
+         * @return the page size
+         */
         public int getSize() { return size; }
+
+        /**
+         * Sets the size of the page.
+         *
+         * @param size the page size to set
+         */
         public void setSize(int size) { this.size = size; }
 
+        /**
+         * Gets the total number of elements across all pages.
+         *
+         * @return the total elements
+         */
         public long getTotalElements() { return totalElements; }
+
+        /**
+         * Sets the total number of elements across all pages.
+         *
+         * @param totalElements the total elements to set
+         */
         public void setTotalElements(long totalElements) { this.totalElements = totalElements; }
 
+        /**
+         * Gets the total number of pages.
+         *
+         * @return the total pages
+         */
         public int getTotalPages() { return totalPages; }
+
+        /**
+         * Sets the total number of pages.
+         *
+         * @param totalPages the total pages to set
+         */
         public void setTotalPages(int totalPages) { this.totalPages = totalPages; }
     }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/ReportDetailResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/ReportDetailResult.java
@@ -17,29 +17,120 @@ public class ReportDetailResult {
     private String targetFullContent;
     private String createdAt;
 
+    /**
+     * Default constructor for ReportDetailResult.
+     */
     public ReportDetailResult() {}
 
+    /**
+     * Gets the ID of the report.
+     *
+     * @return the report ID
+     */
     public String getId() { return id; }
+
+    /**
+     * Sets the ID of the report.
+     *
+     * @param id the report ID to set
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the username of the reporter.
+     *
+     * @return the reporter username
+     */
     public String getReporterUsername() { return reporterUsername; }
+
+    /**
+     * Sets the username of the reporter.
+     *
+     * @param reporterUsername the reporter username to set
+     */
     public void setReporterUsername(String reporterUsername) { this.reporterUsername = reporterUsername; }
 
+    /**
+     * Gets the reason for the report.
+     *
+     * @return the reason
+     */
     public String getReason() { return reason; }
+
+    /**
+     * Sets the reason for the report.
+     *
+     * @param reason the reason to set
+     */
     public void setReason(String reason) { this.reason = reason; }
 
+    /**
+     * Gets the type of the reported target (e.g. review or comment).
+     *
+     * @return the target type
+     */
     public String getType() { return type; }
+
+    /**
+     * Sets the type of the reported target.
+     *
+     * @param type the target type to set
+     */
     public void setType(String type) { this.type = type; }
 
+    /**
+     * Gets the ID of the reported target.
+     *
+     * @return the target ID
+     */
     public String getTargetId() { return targetId; }
+
+    /**
+     * Sets the ID of the reported target.
+     *
+     * @param targetId the target ID to set
+     */
     public void setTargetId(String targetId) { this.targetId = targetId; }
 
+    /**
+     * Gets the username of the author of the reported target.
+     *
+     * @return the target author username
+     */
     public String getTargetAuthorUsername() { return targetAuthorUsername; }
+
+    /**
+     * Sets the username of the author of the reported target.
+     *
+     * @param targetAuthorUsername the target author username to set
+     */
     public void setTargetAuthorUsername(String targetAuthorUsername) { this.targetAuthorUsername = targetAuthorUsername; }
 
+    /**
+     * Gets the full content of the reported target.
+     *
+     * @return the target full content
+     */
     public String getTargetFullContent() { return targetFullContent; }
+
+    /**
+     * Sets the full content of the reported target.
+     *
+     * @param targetFullContent the target full content to set
+     */
     public void setTargetFullContent(String targetFullContent) { this.targetFullContent = targetFullContent; }
 
+    /**
+     * Gets the creation date of the report.
+     *
+     * @return the created at date
+     */
     public String getCreatedAt() { return createdAt; }
+
+    /**
+     * Sets the creation date of the report.
+     *
+     * @param createdAt the created at date to set
+     */
     public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/ReportResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/ReportResult.java
@@ -14,23 +14,80 @@ public class ReportResult {
     private String contentPreview;
     private String createdAt;
 
+    /**
+     * Default constructor for Jackson.
+     */
     public ReportResult() {}
 
+    /**
+     * Gets the report ID.
+     * @return the report ID
+     */
     public String getId() { return id; }
+    
+    /**
+     * Sets the report ID.
+     * @param id the report ID
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the username of the user who made the report.
+     * @return the reporter username
+     */
     public String getReporterUsername() { return reporterUsername; }
+    
+    /**
+     * Sets the username of the user who made the report.
+     * @param reporterUsername the reporter username
+     */
     public void setReporterUsername(String reporterUsername) { this.reporterUsername = reporterUsername; }
 
+    /**
+     * Gets the reason for the report.
+     * @return the report reason
+     */
     public String getReason() { return reason; }
+    
+    /**
+     * Sets the reason for the report.
+     * @param reason the report reason
+     */
     public void setReason(String reason) { this.reason = reason; }
 
+    /**
+     * Gets the type of the report.
+     * @return the report type
+     */
     public String getType() { return type; }
+    
+    /**
+     * Sets the type of the report.
+     * @param type the report type
+     */
     public void setType(String type) { this.type = type; }
 
+    /**
+     * Gets the preview content of what is reported.
+     * @return the content preview
+     */
     public String getContentPreview() { return contentPreview; }
+    
+    /**
+     * Sets the preview content of what is reported.
+     * @param contentPreview the content preview
+     */
     public void setContentPreview(String contentPreview) { this.contentPreview = contentPreview; }
 
+    /**
+     * Gets the creation timestamp of the report.
+     * @return the creation timestamp
+     */
     public String getCreatedAt() { return createdAt; }
+    
+    /**
+     * Sets the creation timestamp of the report.
+     * @param createdAt the creation timestamp
+     */
     public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/ReviewReportResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/ReviewReportResult.java
@@ -13,17 +13,64 @@ public class ReviewReportResult {
     private String reason;
     private String createdAt;
 
+    /**
+     * Default constructor for ReviewReportResult.
+     */
     public ReviewReportResult() {}
 
+    /**
+     * Gets the ID of the report.
+     *
+     * @return the report ID
+     */
     public String getId() { return id; }
+
+    /**
+     * Sets the ID of the report.
+     *
+     * @param id the report ID to set
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the username of the reporter.
+     *
+     * @return the reporter username
+     */
     public String getReporterUsername() { return reporterUsername; }
+
+    /**
+     * Sets the username of the reporter.
+     *
+     * @param reporterUsername the reporter username to set
+     */
     public void setReporterUsername(String reporterUsername) { this.reporterUsername = reporterUsername; }
 
+    /**
+     * Gets the reason for the report.
+     *
+     * @return the reason
+     */
     public String getReason() { return reason; }
+
+    /**
+     * Sets the reason for the report.
+     *
+     * @param reason the reason to set
+     */
     public void setReason(String reason) { this.reason = reason; }
 
+    /**
+     * Gets the creation date of the report.
+     *
+     * @return the created at date
+     */
     public String getCreatedAt() { return createdAt; }
+
+    /**
+     * Sets the creation date of the report.
+     *
+     * @param createdAt the created at date to set
+     */
     public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/ReviewResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/ReviewResult.java
@@ -16,29 +16,120 @@ public class ReviewResult {
     private String createdAt;
     private long reportCount;
 
+    /**
+     * Default constructor for ReviewResult.
+     */
     public ReviewResult() {}
 
+    /**
+     * Gets the ID of the review.
+     *
+     * @return the review ID
+     */
     public String getId() { return id; }
+
+    /**
+     * Sets the ID of the review.
+     *
+     * @param id the review ID to set
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the content of the review.
+     *
+     * @return the review content
+     */
     public String getContent() { return content; }
+
+    /**
+     * Sets the content of the review.
+     *
+     * @param content the review content to set
+     */
     public void setContent(String content) { this.content = content; }
 
+    /**
+     * Indicates whether the review contains spoilers.
+     *
+     * @return true if it has spoilers, false otherwise
+     */
     public Boolean getHaveSpoilers() { return haveSpoilers; }
+
+    /**
+     * Sets whether the review contains spoilers.
+     *
+     * @param haveSpoilers spoiler flag to set
+     */
     public void setHaveSpoilers(Boolean haveSpoilers) { this.haveSpoilers = haveSpoilers; }
 
+    /**
+     * Gets the ID of the author.
+     *
+     * @return the author ID
+     */
     public String getAuthorId() { return authorId; }
+
+    /**
+     * Sets the ID of the author.
+     *
+     * @param authorId the author ID to set
+     */
     public void setAuthorId(String authorId) { this.authorId = authorId; }
 
+    /**
+     * Gets the username of the author.
+     *
+     * @return the author username
+     */
     public String getAuthorUsername() { return authorUsername; }
+
+    /**
+     * Sets the username of the author.
+     *
+     * @param authorUsername the author username to set
+     */
     public void setAuthorUsername(String authorUsername) { this.authorUsername = authorUsername; }
 
+    /**
+     * Gets the title of the game being reviewed.
+     *
+     * @return the game title
+     */
     public String getGameTitle() { return gameTitle; }
+
+    /**
+     * Sets the title of the game being reviewed.
+     *
+     * @param gameTitle the game title to set
+     */
     public void setGameTitle(String gameTitle) { this.gameTitle = gameTitle; }
 
+    /**
+     * Gets the creation date of the review.
+     *
+     * @return the created at date
+     */
     public String getCreatedAt() { return createdAt; }
+
+    /**
+     * Sets the creation date of the review.
+     *
+     * @param createdAt the created at date to set
+     */
     public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
 
+    /**
+     * Gets the number of times this review has been reported.
+     *
+     * @return the report count
+     */
     public long getReportCount() { return reportCount; }
+
+    /**
+     * Sets the number of times this review has been reported.
+     *
+     * @param reportCount the report count to set
+     */
     public void setReportCount(long reportCount) { this.reportCount = reportCount; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/UserDetailResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/UserDetailResult.java
@@ -22,41 +22,152 @@ public class UserDetailResult {
     private long reviewCount;
     private long reportCount;
 
+    /**
+     * Default constructor for Jackson.
+     */
     public UserDetailResult() {}
 
+    /**
+     * Gets the user ID.
+     * @return the user ID
+     */
     public String getId() { return id; }
+    
+    /**
+     * Sets the user ID.
+     * @param id the user ID
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the username.
+     * @return the username
+     */
     public String getUsername() { return username; }
+    
+    /**
+     * Sets the username.
+     * @param username the username
+     */
     public void setUsername(String username) { this.username = username; }
 
+    /**
+     * Gets the user email.
+     * @return the email
+     */
     public String getEmail() { return email; }
+    
+    /**
+     * Sets the user email.
+     * @param email the email
+     */
     public void setEmail(String email) { this.email = email; }
 
+    /**
+     * Gets the user biography.
+     * @return the bio
+     */
     public String getBio() { return bio; }
+    
+    /**
+     * Sets the user biography.
+     * @param bio the bio
+     */
     public void setBio(String bio) { this.bio = bio; }
 
+    /**
+     * Gets the user profile picture URL.
+     * @return the picture URL
+     */
     public String getPicture() { return picture; }
+    
+    /**
+     * Sets the user profile picture URL.
+     * @param picture the picture URL
+     */
     public void setPicture(String picture) { this.picture = picture; }
 
+    /**
+     * Checks if the user profile is private.
+     * @return true if the profile is private, false otherwise
+     */
     public boolean isPrivate() { return isPrivate; }
+    
+    /**
+     * Sets whether the user profile is private.
+     * @param isPrivate true if private, false otherwise
+     */
     public void setPrivate(boolean isPrivate) { this.isPrivate = isPrivate; }
 
+    /**
+     * Checks if the user is banned.
+     * @return true if the user is banned, false otherwise
+     */
     public boolean isBanned() { return banned; }
+    
+    /**
+     * Sets whether the user is banned.
+     * @param banned true if banned, false otherwise
+     */
     public void setBanned(boolean banned) { this.banned = banned; }
 
+    /**
+     * Gets the user's experience points.
+     * @return XP points
+     */
     public int getXpPoint() { return xpPoint; }
+    
+    /**
+     * Sets the user's experience points.
+     * @param xpPoint XP points
+     */
     public void setXpPoint(int xpPoint) { this.xpPoint = xpPoint; }
 
+    /**
+     * Gets the user's level.
+     * @return user level
+     */
     public int getLevel() { return level; }
+    
+    /**
+     * Sets the user's level.
+     * @param level user level
+     */
     public void setLevel(int level) { this.level = level; }
 
+    /**
+     * Gets the timestamp when the user account was created.
+     * @return creation timestamp
+     */
     public String getCreatedAt() { return createdAt; }
+    
+    /**
+     * Sets the timestamp when the user account was created.
+     * @param createdAt creation timestamp
+     */
     public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
 
+    /**
+     * Gets the user's total review count.
+     * @return review count
+     */
     public long getReviewCount() { return reviewCount; }
+    
+    /**
+     * Sets the user's total review count.
+     * @param reviewCount review count
+     */
     public void setReviewCount(long reviewCount) { this.reviewCount = reviewCount; }
 
+    /**
+     * Gets the user's total report count.
+     * @return report count
+     */
     public long getReportCount() { return reportCount; }
+    
+    /**
+     * Sets the user's total report count.
+     * @param reportCount report count
+     */
     public void setReportCount(long reportCount) { this.reportCount = reportCount; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/dto/UserResult.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/dto/UserResult.java
@@ -14,17 +14,64 @@ public class UserResult {
     private String email;
     private boolean banned;
 
+    /**
+     * Default constructor for UserResult.
+     */
     public UserResult() {}
 
+    /**
+     * Gets the ID of the user.
+     *
+     * @return the user ID
+     */
     public String getId() { return id; }
+
+    /**
+     * Sets the ID of the user.
+     *
+     * @param id the user ID to set
+     */
     public void setId(String id) { this.id = id; }
 
+    /**
+     * Gets the username of the user.
+     *
+     * @return the username
+     */
     public String getUsername() { return username; }
+
+    /**
+     * Sets the username of the user.
+     *
+     * @param username the username to set
+     */
     public void setUsername(String username) { this.username = username; }
 
+    /**
+     * Gets the email of the user.
+     *
+     * @return the email
+     */
     public String getEmail() { return email; }
+
+    /**
+     * Sets the email of the user.
+     *
+     * @param email the email to set
+     */
     public void setEmail(String email) { this.email = email; }
 
+    /**
+     * Checks if the user is banned.
+     *
+     * @return true if the user is banned, false otherwise
+     */
     public boolean isBanned() { return banned; }
+
+    /**
+     * Sets the banned status of the user.
+     *
+     * @param banned the banned status to set
+     */
     public void setBanned(boolean banned) { this.banned = banned; }
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/exception/ApiException.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/exception/ApiException.java
@@ -1,9 +1,25 @@
 package com.seyzeriat.desktop.exception;
 
+/**
+ * Exception thrown when an error occurs during API communication.
+ */
 public class ApiException extends Exception {
+    
+    /**
+     * Constructs a new ApiException with the specified detail message.
+     *
+     * @param message the detail message explaining the reason for the exception
+     */
     public ApiException(String message) {
         super(message);
     }
+    
+    /**
+     * Constructs a new ApiException with the specified detail message and cause.
+     *
+     * @param message the detail message explaining the reason for the exception
+     * @param cause the underlying cause of the exception
+     */
     public ApiException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/exception/AuthenticationException.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/exception/AuthenticationException.java
@@ -1,6 +1,15 @@
 package com.seyzeriat.desktop.exception;
 
+/**
+ * Exception thrown when authentication fails.
+ */
 public class AuthenticationException extends Exception {
+    
+    /**
+     * Constructs a new AuthenticationException with the specified detail message.
+     *
+     * @param message the detail message explaining the reason for the exception
+     */
     public AuthenticationException(String message) {
         super(message);
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/exception/GameReferencedException.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/exception/GameReferencedException.java
@@ -2,14 +2,27 @@ package com.seyzeriat.desktop.exception;
 
 import java.util.Map;
 
+/**
+ * Exception thrown when a game cannot be deleted because it is still referenced by other entities.
+ */
 public class GameReferencedException extends Exception {
     private final Map<String, Long> blockingReferences;
 
+    /**
+     * Constructs a new GameReferencedException with the given blocking references.
+     *
+     * @param blockingReferences a map containing the types and counts of blocking references
+     */
     public GameReferencedException(Map<String, Long> blockingReferences) {
         super("Game is still referenced and cannot be deleted.");
         this.blockingReferences = blockingReferences;
     }
 
+    /**
+     * Gets the map of references that are preventing the deletion of the game.
+     *
+     * @return a map of blocking references
+     */
     public Map<String, Long> getBlockingReferences() {
         return blockingReferences;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/exception/UnauthorizedException.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/exception/UnauthorizedException.java
@@ -1,6 +1,15 @@
 package com.seyzeriat.desktop.exception;
 
+/**
+ * Exception thrown when a user attempts to access a resource without sufficient authorization.
+ */
 public class UnauthorizedException extends Exception {
+    
+    /**
+     * Constructs a new UnauthorizedException with the specified detail message.
+     *
+     * @param message the detail message explaining the reason for the exception
+     */
     public UnauthorizedException(String message) {
         super(message);
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/AnalyticsService.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/AnalyticsService.java
@@ -4,6 +4,18 @@ import java.io.IOException;
 import com.seyzeriat.desktop.dto.AnalyticsResult;
 import com.seyzeriat.desktop.exception.UnauthorizedException;
 
+/**
+ * Service interface for retrieving application analytics.
+ */
 public interface AnalyticsService {
+
+    /**
+     * Retrieves analytics information.
+     *
+     * @return the analytics result containing metrics
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     AnalyticsResult getAnalytics() throws IOException, InterruptedException, UnauthorizedException;
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/AuthenticationService.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/AuthenticationService.java
@@ -2,8 +2,30 @@ package com.seyzeriat.desktop.service;
 
 import com.seyzeriat.desktop.exception.AuthenticationException;
 
+/**
+ * Service interface for managing user authentication.
+ * Provides operations to login, logout, and refresh access tokens.
+ */
 public interface AuthenticationService {
+
+    /**
+     * Authenticates a user with their email and password.
+     *
+     * @param email the user's email address
+     * @param password the user's password
+     * @throws AuthenticationException if the authentication fails
+     */
     void login(String email, String password) throws AuthenticationException;
+
+    /**
+     * Refreshes the authentication tokens using the current refresh token.
+     *
+     * @throws AuthenticationException if the token refresh fails
+     */
     void refreshTokens() throws AuthenticationException;
+
+    /**
+     * Logs out the current user by clearing the authentication tokens.
+     */
     void logout();
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/GameService.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/GameService.java
@@ -6,20 +6,153 @@ import com.seyzeriat.desktop.dto.*;
 import com.seyzeriat.desktop.exception.UnauthorizedException;
 import com.seyzeriat.desktop.exception.GameReferencedException;
 
+/**
+ * Service interface for managing games.
+ * Provides operations to search, import, manage, and retrieve game details and catalogs.
+ */
 public interface GameService {
+
+    /**
+     * Searches for games in an external system.
+     *
+     * @param query the search query
+     * @param limit the maximum number of results to return
+     * @return a list of external game results
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     List<ExternalGameResult> searchExternalGames(String query, int limit) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Imports a game from an external system.
+     *
+     * @param externalId the external identifier of the game to import
+     * @return the result of the imported game
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     ImportedGameResult importGame(Long externalId) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Starts a job to import top-rated games.
+     *
+     * @param limit the maximum number of games to import
+     * @param minRatingCount the minimum rating count for the games to be imported
+     * @return the status of the import job
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     ImportJobStatus startTopRatedImport(int limit, int minRatingCount) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Starts a job to import recent games.
+     *
+     * @param limit the maximum number of recent games to import
+     * @return the status of the import job
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     ImportJobStatus startRecentImport(int limit) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Retrieves the status of a specific import job.
+     *
+     * @param jobId the unique identifier of the import job
+     * @return the current status of the job
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     ImportJobStatus getImportJob(String jobId) throws IOException, InterruptedException, UnauthorizedException;
     
+    /**
+     * Retrieves a paginated list of games.
+     *
+     * @param page the page number to retrieve (zero-based)
+     * @param size the maximum number of items per page
+     * @return a paged response containing game summaries
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     PagedResponse<GameSummaryResult> getGames(int page, int size) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Retrieves detailed information about a specific game.
+     *
+     * @param id the unique identifier of the game
+     * @return the detailed result for the specified game
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     GameDetailResult getGameDetail(String id) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Creates a new game.
+     *
+     * @param payload the payload containing the details for the new game
+     * @return the detailed result for the newly created game
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     GameDetailResult createGame(GameFormPayload payload) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Updates an existing game.
+     *
+     * @param id the unique identifier of the game to update
+     * @param payload the payload containing the updated details
+     * @return the detailed result for the updated game
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     GameDetailResult updateGame(String id, GameFormPayload payload) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Deletes a specific game.
+     *
+     * @param id the unique identifier of the game to delete
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     * @throws GameReferencedException if the game cannot be deleted because it is referenced elsewhere
+     */
     void deleteGame(String id) throws IOException, InterruptedException, UnauthorizedException, GameReferencedException;
     
+    /**
+     * Retrieves a list of available genres.
+     *
+     * @return a list of genre options
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     List<CatalogOption> getGenres() throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Retrieves a list of available platforms.
+     *
+     * @return a list of platform options
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     List<CatalogOption> getPlatforms() throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Retrieves a list of available companies.
+     *
+     * @return a list of company options
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     List<CatalogOption> getCompanies() throws IOException, InterruptedException, UnauthorizedException;
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/NewsService.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/NewsService.java
@@ -6,11 +6,76 @@ import com.seyzeriat.desktop.dto.NewsRequestPayload;
 import com.seyzeriat.desktop.dto.PagedResponse;
 import com.seyzeriat.desktop.exception.UnauthorizedException;
 
+/**
+ * Service interface for managing news.
+ * Provides operations to create, retrieve, update, delete, and publish news articles.
+ */
 public interface NewsService {
+
+    /**
+     * Retrieves a paginated list of news articles.
+     *
+     * @param page the page number to retrieve (zero-based)
+     * @param size the maximum number of items per page
+     * @param sort the sorting criteria for the news
+     * @return a paged response containing news results
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     PagedResponse<NewsResult> getNews(int page, int size, String sort) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Creates a new news article.
+     *
+     * @param payload the payload containing the details for the new news article
+     * @return the newly created news result
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     NewsResult createNews(NewsRequestPayload payload) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Updates an existing news article.
+     *
+     * @param id the unique identifier of the news article to update
+     * @param payload the payload containing the updated details
+     * @return the updated news result
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     NewsResult updateNews(String id, NewsRequestPayload payload) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Deletes a specific news article.
+     *
+     * @param id the unique identifier of the news article to delete
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     void deleteNews(String id) throws IOException, InterruptedException, UnauthorizedException;
+    /**
+     * Publishes a specific news article.
+     *
+     * @param id the unique identifier of the news article to publish
+     * @return the published news result
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     NewsResult publishNews(String id) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Unpublishes a specific news article.
+     *
+     * @param id the unique identifier of the news article to unpublish
+     * @return the unpublished news result
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     NewsResult unpublishNews(String id) throws IOException, InterruptedException, UnauthorizedException;
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/ReportService.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/ReportService.java
@@ -6,8 +6,41 @@ import com.seyzeriat.desktop.dto.ReportDetailResult;
 import com.seyzeriat.desktop.dto.PagedResponse;
 import com.seyzeriat.desktop.exception.UnauthorizedException;
 
+/**
+ * Service interface for managing reports.
+ * Provides operations to retrieve and manage reports within the application.
+ */
 public interface ReportService {
+
+    /**
+     * Retrieves a paginated list of reports.
+     *
+     * @param page the page number to retrieve (zero-based)
+     * @param size the maximum number of items per page
+     * @return a paged response containing report results
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     PagedResponse<ReportResult> getReports(int page, int size) throws IOException, InterruptedException, UnauthorizedException;
+    /**
+     * Dismisses a specific report by its identifier.
+     *
+     * @param id the unique identifier of the report to dismiss
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     void dismissReport(String id) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Retrieves detailed information about a specific report.
+     *
+     * @param id the unique identifier of the report
+     * @return the detailed result for the specified report
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     ReportDetailResult getReportById(String id) throws IOException, InterruptedException, UnauthorizedException;
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/ReviewService.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/ReviewService.java
@@ -6,10 +6,65 @@ import com.seyzeriat.desktop.dto.ReviewReportResult;
 import com.seyzeriat.desktop.dto.PagedResponse;
 import com.seyzeriat.desktop.exception.UnauthorizedException;
 
+/**
+ * Service interface for managing reviews and related reports.
+ * Provides operations to retrieve, delete, and manage user reviews and comments.
+ */
 public interface ReviewService {
+
+    /**
+     * Retrieves a paginated list of reviews.
+     *
+     * @param page the page number to retrieve (zero-based)
+     * @param size the maximum number of items per page
+     * @return a paged response containing review results
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     PagedResponse<ReviewResult> getReviews(int page, int size) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Retrieves a paginated list of reviews that have been reported.
+     *
+     * @param page the page number to retrieve (zero-based)
+     * @param size the maximum number of items per page
+     * @return a paged response containing reported review results
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     PagedResponse<ReviewResult> getReportedReviews(int page, int size) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Retrieves a paginated list of reports for a specific review.
+     *
+     * @param reviewId the unique identifier of the review
+     * @param page the page number to retrieve (zero-based)
+     * @param size the maximum number of items per page
+     * @return a paged response containing review report results
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     PagedResponse<ReviewReportResult> getReviewReports(String reviewId, int page, int size) throws IOException, InterruptedException, UnauthorizedException;
+    /**
+     * Deletes a specific review by its identifier.
+     *
+     * @param id the unique identifier of the review to delete
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     void deleteReview(String id) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Deletes a specific comment by its identifier.
+     *
+     * @param id the unique identifier of the comment to delete
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     void deleteComment(String id) throws IOException, InterruptedException, UnauthorizedException;
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/TokenManager.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/TokenManager.java
@@ -16,6 +16,11 @@ public final class TokenManager {
 
     private TokenManager() {}
 
+    /**
+     * Returns the singleton instance of {@code TokenManager}.
+     *
+     * @return the token manager instance
+     */
     public static TokenManager getInstance() {
         return INSTANCE;
     }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/UserService.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/UserService.java
@@ -6,10 +6,61 @@ import com.seyzeriat.desktop.dto.UserResult;
 import com.seyzeriat.desktop.dto.UserDetailResult;
 import com.seyzeriat.desktop.exception.UnauthorizedException;
 
+/**
+ * Service interface for managing users.
+ * Provides operations to retrieve, edit, and manage user accounts.
+ */
 public interface UserService {
+
+    /**
+     * Retrieves a list of all users.
+     *
+     * @return a list containing the user results
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     List<UserResult> getUsers() throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Retrieves detailed information about a specific user.
+     *
+     * @param id the unique identifier of the user
+     * @return the detailed result for the specified user
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     UserDetailResult getUserDetail(String id) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Edits a specific user's information.
+     *
+     * @param id the unique identifier of the user to edit
+     * @param body the JSON string representing the updated user information
+     * @return the updated detailed user result
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     UserDetailResult editUser(String id, String body) throws IOException, InterruptedException, UnauthorizedException;
+    /**
+     * Bans a specific user.
+     *
+     * @param id the unique identifier of the user to ban
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     void banUser(String id) throws IOException, InterruptedException, UnauthorizedException;
+
+    /**
+     * Unbans a specific user.
+     *
+     * @param id the unique identifier of the user to unban
+     * @throws IOException if an I/O error occurs during the operation
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized to access this resource
+     */
     void unbanUser(String id) throws IOException, InterruptedException, UnauthorizedException;
 }

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/impl/AnalyticsApiClient.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/impl/AnalyticsApiClient.java
@@ -10,12 +10,29 @@ import com.seyzeriat.desktop.exception.UnauthorizedException;
 import com.seyzeriat.desktop.service.AnalyticsService;
 import com.seyzeriat.desktop.service.AuthenticationService;
 
+/**
+ * API client implementation for {@link AnalyticsService}.
+ * Handles HTTP communication with the backend to retrieve analytics.
+ */
 public class AnalyticsApiClient extends BaseApiClient implements AnalyticsService {
 
+    /**
+     * Constructs a new AnalyticsApiClient with the specified authentication service.
+     *
+     * @param authService the authentication service to use for securing requests
+     */
     public AnalyticsApiClient(AuthenticationService authService) {
         super(authService);
     }
 
+    /**
+     * Retrieves analytics information.
+     *
+     * @return the analytics result containing metrics
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public AnalyticsResult getAnalytics() throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/analytics";

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/impl/AuthApiClient.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/impl/AuthApiClient.java
@@ -13,6 +13,10 @@ import com.seyzeriat.desktop.exception.AuthenticationException;
 import com.seyzeriat.desktop.service.AuthenticationService;
 import com.seyzeriat.desktop.service.TokenManager;
 
+/**
+ * API client implementation for {@link AuthenticationService}.
+ * Handles HTTP communication with the backend to manage user authentication.
+ */
 public class AuthApiClient implements AuthenticationService {
 
     private static final String BASE_URL = "http://localhost:8080";
@@ -20,16 +24,31 @@ public class AuthApiClient implements AuthenticationService {
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
 
+    /**
+     * Constructs a new AuthApiClient using the default HTTP client.
+     */
     public AuthApiClient() {
         this(HttpClient.newHttpClient());
     }
 
+    /**
+     * Constructs a new AuthApiClient with a provided HTTP client.
+     *
+     * @param httpClient the HTTP client to use for requests
+     */
     public AuthApiClient(HttpClient httpClient) {
         this.httpClient = httpClient;
         this.objectMapper = new ObjectMapper();
         this.objectMapper.registerModule(new JavaTimeModule());
     }
 
+    /**
+     * Authenticates a user with their email and password.
+     *
+     * @param email the user's email address
+     * @param password the user's password
+     * @throws AuthenticationException if the authentication fails
+     */
     @Override
     public void login(String email, String password) throws AuthenticationException {
         String jsonBody = String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
@@ -65,6 +84,11 @@ public class AuthApiClient implements AuthenticationService {
         }
     }
 
+    /**
+     * Refreshes the authentication tokens using the current refresh token.
+     *
+     * @throws AuthenticationException if the token refresh fails
+     */
     @Override
     public void refreshTokens() throws AuthenticationException {
         String refreshToken = TokenManager.getInstance().getRefreshToken();
@@ -107,6 +131,9 @@ public class AuthApiClient implements AuthenticationService {
         }
     }
 
+    /**
+     * Logs out the current user by clearing the authentication tokens.
+     */
     @Override
     public void logout() {
         TokenManager.getInstance().clear();

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/impl/BaseApiClient.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/impl/BaseApiClient.java
@@ -14,6 +14,11 @@ import com.seyzeriat.desktop.exception.UnauthorizedException;
 import com.seyzeriat.desktop.service.AuthenticationService;
 import com.seyzeriat.desktop.service.TokenManager;
 
+/**
+ * Abstract base class for API clients.
+ * Provides common functionality for handling HTTP requests, including authentication
+ * and token management.
+ */
 public abstract class BaseApiClient {
 
     protected static final String BASE_URL = "http://localhost:8080/api/v1";
@@ -21,10 +26,21 @@ public abstract class BaseApiClient {
     protected final ObjectMapper objectMapper;
     private final AuthenticationService authService;
 
+    /**
+     * Constructs a new BaseApiClient using the default HTTP client.
+     *
+     * @param authService the authentication service to manage tokens
+     */
     public BaseApiClient(AuthenticationService authService) {
         this(authService, HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build());
     }
 
+    /**
+     * Constructs a new BaseApiClient with a specified HTTP client.
+     *
+     * @param authService the authentication service to manage tokens
+     * @param httpClient  the HTTP client to use for requests
+     */
     public BaseApiClient(AuthenticationService authService, HttpClient httpClient) {
         this.authService = authService;
         this.httpClient = httpClient;

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/impl/GameApiClient.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/impl/GameApiClient.java
@@ -25,16 +25,41 @@ import com.seyzeriat.desktop.exception.UnauthorizedException;
 import com.seyzeriat.desktop.service.AuthenticationService;
 import com.seyzeriat.desktop.service.GameService;
 
+/**
+ * API client implementation for {@link GameService}.
+ * Handles HTTP communication with the backend to search, import, and manage games.
+ */
 public class GameApiClient extends BaseApiClient implements GameService {
 
+    /**
+     * Constructs a new GameApiClient with the specified authentication service.
+     *
+     * @param authService the authentication service to use for securing requests
+     */
     public GameApiClient(AuthenticationService authService) {
         super(authService);
     }
 
+    /**
+     * Constructs a new GameApiClient with the specified authentication service and HTTP client.
+     *
+     * @param authService the authentication service
+     * @param httpClient  the HTTP client to use for requests
+     */
     public GameApiClient(AuthenticationService authService, java.net.http.HttpClient httpClient) {
         super(authService, httpClient);
     }
 
+    /**
+     * Searches for games in an external system.
+     *
+     * @param query the search query
+     * @param limit the maximum number of results to return
+     * @return a list of external game results
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public List<ExternalGameResult> searchExternalGames(String query, int limit) throws IOException, InterruptedException, UnauthorizedException {
         String encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8);
@@ -54,6 +79,15 @@ public class GameApiClient extends BaseApiClient implements GameService {
         return objectMapper.readValue(response.body(), new TypeReference<List<ExternalGameResult>>() {});
     }
 
+    /**
+     * Imports a game from an external system.
+     *
+     * @param externalId the external identifier of the game to import
+     * @return the result of the imported game
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public ImportedGameResult importGame(Long externalId) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/games/import/" + externalId;
@@ -72,12 +106,31 @@ public class GameApiClient extends BaseApiClient implements GameService {
         return objectMapper.readValue(response.body(), ImportedGameResult.class);
     }
 
+    /**
+     * Starts a job to import top-rated games.
+     *
+     * @param limit the maximum number of games to import
+     * @param minRatingCount the minimum rating count for the games to be imported
+     * @return the status of the import job
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public ImportJobStatus startTopRatedImport(int limit, int minRatingCount) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/games/import/top-rated?limit=" + limit + "&minRatingCount=" + minRatingCount;
         return startImportJob(url);
     }
 
+    /**
+     * Starts a job to import recent games.
+     *
+     * @param limit the maximum number of recent games to import
+     * @return the status of the import job
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public ImportJobStatus startRecentImport(int limit) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/games/import/recent?limit=" + limit;
@@ -102,6 +155,15 @@ public class GameApiClient extends BaseApiClient implements GameService {
         return objectMapper.readValue(response.body(), ImportJobStatus.class);
     }
 
+    /**
+     * Retrieves the status of a specific import job.
+     *
+     * @param jobId the unique identifier of the import job
+     * @return the current status of the job
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public ImportJobStatus getImportJob(String jobId) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/games/import/jobs/" + jobId;
@@ -123,6 +185,16 @@ public class GameApiClient extends BaseApiClient implements GameService {
         return objectMapper.readValue(response.body(), ImportJobStatus.class);
     }
 
+    /**
+     * Retrieves a paginated list of games.
+     *
+     * @param page the page number to retrieve
+     * @param size the maximum number of items per page
+     * @return a paged response containing game summaries
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public PagedResponse<GameSummaryResult> getGames(int page, int size) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/games?page=" + page + "&size=" + size + "&sort=title,asc";
@@ -141,6 +213,15 @@ public class GameApiClient extends BaseApiClient implements GameService {
         return objectMapper.readValue(response.body(), new TypeReference<PagedResponse<GameSummaryResult>>() {});
     }
 
+    /**
+     * Retrieves detailed information about a specific game.
+     *
+     * @param id the unique identifier of the game
+     * @return the detailed result for the specified game
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public GameDetailResult getGameDetail(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/games/" + id;
@@ -159,6 +240,15 @@ public class GameApiClient extends BaseApiClient implements GameService {
         return objectMapper.readValue(response.body(), GameDetailResult.class);
     }
 
+    /**
+     * Creates a new game.
+     *
+     * @param payload the payload containing the details for the new game
+     * @return the detailed result for the newly created game
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public GameDetailResult createGame(GameFormPayload payload) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/games";
@@ -179,6 +269,16 @@ public class GameApiClient extends BaseApiClient implements GameService {
         return objectMapper.readValue(response.body(), GameDetailResult.class);
     }
 
+    /**
+     * Updates an existing game.
+     *
+     * @param id the unique identifier of the game to update
+     * @param payload the payload containing the updated details
+     * @return the detailed result for the updated game
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public GameDetailResult updateGame(String id, GameFormPayload payload) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/games/" + id;
@@ -199,6 +299,15 @@ public class GameApiClient extends BaseApiClient implements GameService {
         return objectMapper.readValue(response.body(), GameDetailResult.class);
     }
 
+    /**
+     * Deletes a specific game.
+     *
+     * @param id the unique identifier of the game to delete
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     * @throws GameReferencedException if the game cannot be deleted because it is referenced elsewhere
+     */
     @Override
     public void deleteGame(String id) throws IOException, InterruptedException, UnauthorizedException, GameReferencedException {
         String url = BASE_URL + "/admin/games/" + id;
@@ -228,16 +337,40 @@ public class GameApiClient extends BaseApiClient implements GameService {
         }
     }
 
+    /**
+     * Retrieves a list of available genres.
+     *
+     * @return a list of genre options
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public List<CatalogOption> getGenres() throws IOException, InterruptedException, UnauthorizedException {
         return fetchCatalogOptions("/genres");
     }
 
+    /**
+     * Retrieves a list of available platforms.
+     *
+     * @return a list of platform options
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public List<CatalogOption> getPlatforms() throws IOException, InterruptedException, UnauthorizedException {
         return fetchCatalogOptions("/platforms");
     }
 
+    /**
+     * Retrieves a list of available companies.
+     *
+     * @return a list of company options
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public List<CatalogOption> getCompanies() throws IOException, InterruptedException, UnauthorizedException {
         return fetchCatalogOptions("/companies");

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/impl/NewsApiClient.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/impl/NewsApiClient.java
@@ -13,12 +13,32 @@ import com.seyzeriat.desktop.exception.UnauthorizedException;
 import com.seyzeriat.desktop.service.AuthenticationService;
 import com.seyzeriat.desktop.service.NewsService;
 
+/**
+ * API client implementation for {@link NewsService}.
+ * Handles HTTP communication with the backend to manage news articles.
+ */
 public class NewsApiClient extends BaseApiClient implements NewsService {
 
+    /**
+     * Constructs a new NewsApiClient with the specified authentication service.
+     *
+     * @param authService the authentication service to use for securing requests
+     */
     public NewsApiClient(AuthenticationService authService) {
         super(authService);
     }
 
+    /**
+     * Retrieves a paginated list of news articles.
+     *
+     * @param page the page number to retrieve
+     * @param size the maximum number of items per page
+     * @param sort the sorting criteria for the news
+     * @return a paged response containing news results
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public PagedResponse<NewsResult> getNews(int page, int size, String sort) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/news?page=" + page + "&size=" + size + "&sort=" + sort;
@@ -37,6 +57,15 @@ public class NewsApiClient extends BaseApiClient implements NewsService {
         return objectMapper.readValue(response.body(), new TypeReference<PagedResponse<NewsResult>>() {});
     }
 
+    /**
+     * Creates a new news article.
+     *
+     * @param payload the payload containing the details for the new news article
+     * @return the newly created news result
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public NewsResult createNews(NewsRequestPayload payload) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/news";
@@ -56,6 +85,16 @@ public class NewsApiClient extends BaseApiClient implements NewsService {
         return objectMapper.readValue(response.body(), NewsResult.class);
     }
 
+    /**
+     * Updates an existing news article.
+     *
+     * @param id the unique identifier of the news article to update
+     * @param payload the payload containing the updated details
+     * @return the updated news result
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public NewsResult updateNews(String id, NewsRequestPayload payload) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/news/" + id;
@@ -75,6 +114,14 @@ public class NewsApiClient extends BaseApiClient implements NewsService {
         return objectMapper.readValue(response.body(), NewsResult.class);
     }
 
+    /**
+     * Deletes a specific news article.
+     *
+     * @param id the unique identifier of the news article to delete
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public void deleteNews(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/news/" + id;
@@ -90,6 +137,15 @@ public class NewsApiClient extends BaseApiClient implements NewsService {
         }
     }
 
+    /**
+     * Publishes a specific news article.
+     *
+     * @param id the unique identifier of the news article to publish
+     * @return the published news result
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public NewsResult publishNews(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/news/" + id + "/publish";
@@ -108,6 +164,15 @@ public class NewsApiClient extends BaseApiClient implements NewsService {
         return objectMapper.readValue(response.body(), NewsResult.class);
     }
 
+    /**
+     * Unpublishes a specific news article.
+     *
+     * @param id the unique identifier of the news article to unpublish
+     * @return the unpublished news result
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public NewsResult unpublishNews(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/news/" + id + "/unpublish";

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/impl/ReportApiClient.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/impl/ReportApiClient.java
@@ -13,12 +13,31 @@ import com.seyzeriat.desktop.exception.UnauthorizedException;
 import com.seyzeriat.desktop.service.AuthenticationService;
 import com.seyzeriat.desktop.service.ReportService;
 
+/**
+ * API client implementation for {@link ReportService}.
+ * Handles HTTP communication with the backend to manage reports.
+ */
 public class ReportApiClient extends BaseApiClient implements ReportService {
 
+    /**
+     * Constructs a new ReportApiClient with the specified authentication service.
+     *
+     * @param authService the authentication service to use for securing requests
+     */
     public ReportApiClient(AuthenticationService authService) {
         super(authService);
     }
 
+    /**
+     * Retrieves a paginated list of reports.
+     *
+     * @param page the page number to retrieve
+     * @param size the maximum number of items per page
+     * @return a paged response containing report results
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public PagedResponse<ReportResult> getReports(int page, int size) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/reports?page=" + page + "&size=" + size;
@@ -37,6 +56,14 @@ public class ReportApiClient extends BaseApiClient implements ReportService {
         return objectMapper.readValue(response.body(), new TypeReference<PagedResponse<ReportResult>>() {});
     }
 
+    /**
+     * Dismisses a specific report by its identifier.
+     *
+     * @param id the unique identifier of the report to dismiss
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public void dismissReport(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/reports/" + id;
@@ -52,6 +79,15 @@ public class ReportApiClient extends BaseApiClient implements ReportService {
         }
     }
 
+    /**
+     * Retrieves detailed information about a specific report.
+     *
+     * @param id the unique identifier of the report
+     * @return the detailed result for the specified report
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public ReportDetailResult getReportById(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/reports/" + id;

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/impl/ReviewApiClient.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/impl/ReviewApiClient.java
@@ -13,12 +13,31 @@ import com.seyzeriat.desktop.exception.UnauthorizedException;
 import com.seyzeriat.desktop.service.AuthenticationService;
 import com.seyzeriat.desktop.service.ReviewService;
 
+/**
+ * API client implementation for {@link ReviewService}.
+ * Handles HTTP communication with the backend to manage reviews.
+ */
 public class ReviewApiClient extends BaseApiClient implements ReviewService {
 
+    /**
+     * Constructs a new ReviewApiClient with the specified authentication service.
+     *
+     * @param authService the authentication service to use for securing requests
+     */
     public ReviewApiClient(AuthenticationService authService) {
         super(authService);
     }
 
+    /**
+     * Retrieves a paginated list of reviews.
+     *
+     * @param page the page number to retrieve
+     * @param size the maximum number of items per page
+     * @return a paged response containing review results
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public PagedResponse<ReviewResult> getReviews(int page, int size) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/reviews?page=" + page + "&size=" + size;
@@ -37,6 +56,16 @@ public class ReviewApiClient extends BaseApiClient implements ReviewService {
         return objectMapper.readValue(response.body(), new TypeReference<PagedResponse<ReviewResult>>() {});
     }
 
+    /**
+     * Retrieves a paginated list of reviews that have been reported.
+     *
+     * @param page the page number to retrieve
+     * @param size the maximum number of items per page
+     * @return a paged response containing reported review results
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public PagedResponse<ReviewResult> getReportedReviews(int page, int size) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/reviews/reported?page=" + page + "&size=" + size;
@@ -55,6 +84,17 @@ public class ReviewApiClient extends BaseApiClient implements ReviewService {
         return objectMapper.readValue(response.body(), new TypeReference<PagedResponse<ReviewResult>>() {});
     }
 
+    /**
+     * Retrieves a paginated list of reports for a specific review.
+     *
+     * @param reviewId the unique identifier of the review
+     * @param page the page number to retrieve
+     * @param size the maximum number of items per page
+     * @return a paged response containing review report results
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public PagedResponse<ReviewReportResult> getReviewReports(String reviewId, int page, int size)
             throws IOException, InterruptedException, UnauthorizedException {
@@ -74,6 +114,14 @@ public class ReviewApiClient extends BaseApiClient implements ReviewService {
         return objectMapper.readValue(response.body(), new TypeReference<PagedResponse<ReviewReportResult>>() {});
     }
 
+    /**
+     * Deletes a specific review by its identifier.
+     *
+     * @param id the unique identifier of the review to delete
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public void deleteReview(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/reviews/" + id;
@@ -89,6 +137,14 @@ public class ReviewApiClient extends BaseApiClient implements ReviewService {
         }
     }
 
+    /**
+     * Deletes a specific comment by its identifier.
+     *
+     * @param id the unique identifier of the comment to delete
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public void deleteComment(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/comments/" + id;

--- a/desktop/src/main/java/com/seyzeriat/desktop/service/impl/UserApiClient.java
+++ b/desktop/src/main/java/com/seyzeriat/desktop/service/impl/UserApiClient.java
@@ -13,16 +13,39 @@ import com.seyzeriat.desktop.exception.UnauthorizedException;
 import com.seyzeriat.desktop.service.AuthenticationService;
 import com.seyzeriat.desktop.service.UserService;
 
+/**
+ * API client implementation for {@link UserService}.
+ * Handles HTTP communication with the backend to manage user resources.
+ */
 public class UserApiClient extends BaseApiClient implements UserService {
 
+    /**
+     * Constructs a new UserApiClient with the specified authentication service.
+     *
+     * @param authService the authentication service to use for securing requests
+     */
     public UserApiClient(AuthenticationService authService) {
         super(authService);
     }
 
+    /**
+     * Constructs a new UserApiClient with the specified authentication service and HTTP client.
+     *
+     * @param authService the authentication service
+     * @param httpClient  the HTTP client to use for requests
+     */
     public UserApiClient(AuthenticationService authService, java.net.http.HttpClient httpClient) {
         super(authService, httpClient);
     }
 
+    /**
+     * Retrieves a list of all users.
+     *
+     * @return a list containing the user results
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public List<UserResult> getUsers() throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/users";
@@ -41,6 +64,15 @@ public class UserApiClient extends BaseApiClient implements UserService {
         return objectMapper.readValue(response.body(), new TypeReference<List<UserResult>>() {});
     }
 
+    /**
+     * Retrieves detailed information about a specific user.
+     *
+     * @param id the unique identifier of the user
+     * @return the detailed result for the specified user
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public UserDetailResult getUserDetail(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/users/" + id;
@@ -59,6 +91,16 @@ public class UserApiClient extends BaseApiClient implements UserService {
         return objectMapper.readValue(response.body(), UserDetailResult.class);
     }
 
+    /**
+     * Edits a specific user's information.
+     *
+     * @param id the unique identifier of the user to edit
+     * @param body the JSON string representing the updated user information
+     * @return the updated detailed user result
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public UserDetailResult editUser(String id, String body) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/users/" + id;
@@ -78,6 +120,14 @@ public class UserApiClient extends BaseApiClient implements UserService {
         return objectMapper.readValue(response.body(), UserDetailResult.class);
     }
 
+    /**
+     * Bans a specific user.
+     *
+     * @param id the unique identifier of the user to ban
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public void banUser(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/users/" + id + "/ban";
@@ -93,6 +143,14 @@ public class UserApiClient extends BaseApiClient implements UserService {
         }
     }
 
+    /**
+     * Unbans a specific user.
+     *
+     * @param id the unique identifier of the user to unban
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the operation is interrupted
+     * @throws UnauthorizedException if the user is not authorized
+     */
     @Override
     public void unbanUser(String id) throws IOException, InterruptedException, UnauthorizedException {
         String url = BASE_URL + "/admin/users/" + id + "/unban";

--- a/desktop/src/main/java/module-info.java
+++ b/desktop/src/main/java/module-info.java
@@ -1,3 +1,9 @@
+/**
+ * The main module for the desktop application.
+ * <p>
+ * This module requires JavaFX and Jackson dependencies for the UI and JSON processing,
+ * and exports the necessary packages for running the application.
+ */
 module com.seyzeriat.desktop {
     requires javafx.controls;
     requires javafx.fxml;


### PR DESCRIPTION
## Summary

Added comprehensive class-level and method-level Javadoc comments to all Java files (controllers, services, DTOs, exceptions, etc.) in the `desktop` module. This aligns the desktop module with the documentation standards already in place for the `api` module and improves overall code readability.

    ## Type of change

    - [x] 📝 Documentation

    ## Linked issue

    Closes TE-345

    ## Affected modules

    - [x] `desktop` (JavaFX)

    ## Checklist

    - [x] Conventions in `CLAUDE.md` and `CONTRIBUTING.md` are respected
    - [x] No secrets or credentials are committed
    - [x] Documentation updated if behavior or setup changed
