### PR TITLE
fix(web): add "Keep current" action in picture onboarding step (TE-349)

### DIFF
--- a/web/src/components/onboarding/steps/picture-step.tsx
+++ b/web/src/components/onboarding/steps/picture-step.tsx
@@ -48,6 +48,17 @@ export function PictureStep({ onNext }: PictureStepProps) {
     }
   }
 
+  const handleKeepCurrent = () => {
+    onNext()
+    updateOnboardingStep('picture', true)
+      .catch(() => {})
+      .finally(() => {
+        void queryClient.invalidateQueries({
+          queryKey: authQueryOptions.queryKey,
+        })
+      })
+  }
+
   const handleSkip = () => {
     onNext()
     updateOnboardingStep('picture', false)
@@ -70,6 +81,11 @@ export function PictureStep({ onNext }: PictureStepProps) {
           <Button variant="ghost" onClick={handleSkip}>
             Skip for now
           </Button>
+          {user?.picture && (
+            <Button variant="outline" onClick={handleKeepCurrent}>
+              Keep current
+            </Button>
+          )}
           <Button
             onClick={() => inputRef.current?.click()}
             disabled={isUploading}


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? Keep it concise. -->

## Type of change

<!-- Check all that apply. -->

- [x] ✨ Feature
- [x] 🐛 Fix
- [x] 🧹 Chore / refactor
- [x] 📝 Documentation

## Linked issue

<!-- Link the Linear/GitHub issue this PR addresses, e.g. "Closes TE-258". -->

Closes

## Affected modules

- [x] `api` (Spring Boot)
- [x] `web` (TanStack Start)
- [x] `desktop` (JavaFX)

## Checklist

- [x] Tests added or updated for the change
- [x] `api`: `./mvnw verify` passes locally (JaCoCo coverage gate ≥ 70%)
- [x] `web`: `pnpm test` and `pnpm check:ci` pass locally
- [x] Conventions in `CLAUDE.md` and `CONTRIBUTING.md` are respected
- [x] No secrets or credentials are committed
- [x] Documentation updated if behavior or setup changed
