### PR TITLE
chore(web): remove TanStack devtools from production build

### DIFF
--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,11 +1,9 @@
-import { TanStackDevtools } from '@tanstack/react-devtools'
 import {
   HeadContent,
   Outlet,
   Scripts,
   createRootRouteWithContext,
 } from '@tanstack/react-router'
-import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 
 import { HotkeysProvider } from '@tanstack/react-hotkeys'
 import { ThemeProvider } from 'next-themes'
@@ -94,17 +92,6 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             <TooltipProvider>
               <ErrorBoundary>{children}</ErrorBoundary>
               <Toaster richColors closeButton position="top-right" />
-              <TanStackDevtools
-                config={{
-                  position: 'bottom-right',
-                }}
-                plugins={[
-                  {
-                    name: 'Tanstack Router',
-                    render: <TanStackRouterDevtoolsPanel />,
-                  },
-                ]}
-              />
               <Scripts />
             </TooltipProvider>
           </ThemeProvider>


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? Keep it concise. -->

## Type of change

<!-- Check all that apply. -->

- [ ] ✨ Feature
- [x] 🐛 Fix
- [ ] 🧹 Chore / refactor
- [ ] 📝 Documentation

## Linked issue

<!-- Link the Linear/GitHub issue this PR addresses, e.g. "Closes TE-258". -->

Closes

## Affected modules

- [ ] `api` (Spring Boot)
- [ ] `web` (TanStack Start)
- [ ] `desktop` (JavaFX)

## Checklist

- [ ] Tests added or updated for the change
- [ ] `api`: `./mvnw verify` passes locally (JaCoCo coverage gate ≥ 70%)
- [ ] `web`: `pnpm test` and `pnpm check:ci` pass locally
- [ ] Conventions in `CLAUDE.md` and `CONTRIBUTING.md` are respected
- [ ] No secrets or credentials are committed
- [ ] Documentation updated if behavior or setup changed
